### PR TITLE
Prompt order: verified to share context between scuttle and summarize 

### DIFF
--- a/examples/decode-cert-qwen2.5-instruct-32b-q3k_m.txt
+++ b/examples/decode-cert-qwen2.5-instruct-32b-q3k_m.txt
@@ -1,0 +1,47 @@
+klotz@tensor:~/wip$ help.sh decode < google.cert
+The text you provided is a PEM-encoded X.509 certificate. PEM stands for Privacy Enhanced Mail, a standard for storing and transmitting certificates, keys, and other cryptographic items. This format is widely used because it can be easily transmitted and stored as text.
+The certificate is base64-encoded and includes header and footer lines that indicate the start and end of the certificate data:
+
+- `-----BEGIN CERTIFICATE-----`: Marks the beginning of the certificate.
+- `-----END CERTIFICATE-----`: Marks the end of the certificate.
+
+The certificate contains information about the entity it was issued to, the entity that issued it, and other important details such as the validity period and public key. Here is a brief breakdown of the information contained in your certificate:
+
+- **Country Name (C)**: US
+- **State or Province Name (ST)**: California- **Locality Name (L)**: Mountain View
+- **Organization Name (O)**: Google Inc.
+- **Organizational Unit Name (OU)**: Android
+- **Common Name (CN)**: Android
+- **Validity Period**:
+  - **Not Before**: 2024-07-17 20:44:30
+  - **Not After**: 2054-07-17 20:44:30
+
+This certificate appears to be self-signed as the issuer (Google Inc., Android) and the subject (Android) are the same. The certificate includes a public key used for encryption and authentication purposes.
+
+If you want to decode this certificate further (e.g., extract the public key or more detailed information), you would typically use tools like `openssl`:
+
+```bash
+openssl x509 -in your_certificate.pem -text -noout
+```
+
+This command will print out all the details contained within the certificate in a human-readable format.
+
+klotz@tensor:~/wip$ openssl x509 -in google.cert -text -noout
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number:
+            7f:7a:2d:83:50:d2:8f:81:1f:c6:53:f6:3a:30:1a:a6:84:3f:9a:81
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: C = US, ST = California, L = Mountain View, O = Google Inc., OU = Android, CN = Android
+        Validity
+            Not Before: Jul 17 20:44:30 2024 GMT
+            Not After : Jul 17 20:44:30 2054 GMT
+        Subject: C = US, ST = California, L = Mountain View, O = Google Inc., OU = Android, CN = Android
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (4096 bit)
+                Modulus:
+...
+
+

--- a/scripts/scuttle.sh
+++ b/scripts/scuttle.sh
@@ -74,7 +74,7 @@ function fetch_text() {
     if [ "${fetcher}" == "lynx" ]; then
 	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" -header="Referer: ${SCUTTLE_REFERER}" "${url}"
     elif [ "${fetcher}" == "links" ]; then
-	links -codepage utf-8 -force-html -width 72 -dump  -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
+	links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
     else
 	log_and_exit 3 "error: NOLINKS: fetcher=$fetcher"
 	exit 3

--- a/scripts/scuttle.sh
+++ b/scripts/scuttle.sh
@@ -72,7 +72,8 @@ fi
 function fetch_text() {
     local url="$1"
     if [ "${fetcher}" == "lynx" ]; then
-	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" -header="Referer: ${SCUTTLE_REFERER}" "${url}"
+	# todo: support referer in lynx via -cfg file
+	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" "${url}"
     elif [ "${fetcher}" == "links" ]; then
 	links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
     else

--- a/scripts/scuttle.sh
+++ b/scripts/scuttle.sh
@@ -125,9 +125,10 @@ else
     GRAMMAR_FLAG=""
 fi
 
+POST_PROMPT_ARG='Respond with only a short JSON object with these 4 fields: `link`, `title`, `description`, and `keywords` array'
 LINKS_PRE_PROMPT="Below is a web page article from the specified link address. Follow the instructions after the article."
-SCUTTLE_POST_PROMPT="Summarize the above web page article from ${LINK} and ignore website header at the start and look for the main article.\nRespond with only a short JSON object with these 4 fields: \`link\`, \`title\`, \`description\`, and \`keywords\` array."
+SCUTTLE_POST_PROMPT="Read the above web page article from ${LINK} and ignore website header at the start and look for the main article."
 
-( printf "# Text of link %s\n" "${LINK}"; fetch_text "${LINK}" | ${CAPTURE_COMMAND}; printf "\n# Instructions\n%b\n" "${SCUTTLE_POST_PROMPT}") | \
+( printf "# Text of link %s\n" "${LINK}"; fetch_text "${LINK}" | ${CAPTURE_COMMAND}; printf "\n# Instructions\n%b\n%b\n" "${SCUTTLE_POST_PROMPT}" "${POST_PROMPT_ARG}") | \
     "${SCRIPT_DIR}/llm.sh" --long ${GRAMMAR_FLAG} ${ARGS} "${LINKS_PRE_PROMPT}"| \
     post_process

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -57,9 +57,9 @@ function fetch_text() {
     if [ "${fetcher}" == "lynx" ]; then
 	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" -header="Referer: ${SCUTTLE_REFERER}" "${url}"
     elif [ "${fetcher}" == "links" ]; then
-	links -codepage utf-8 -force-html -width 72 -dump  -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
+	links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
     else
-	echo "error: NOLINKS"
+	echo "error: NOLINKS: fetcher=$fetcher"
 	exit 1
     fi
 }

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -17,7 +17,10 @@ if [ "$1" == "--capture-file" ]; then
 fi
 
 LINK=${1:-}			# LAST
-ARGS=${@:2}			# BUTLAST
+# todo: actually everything up to a '--' should go into POST_PROMPT and everything after '--' should go into the ARGS.
+POST_PROMPT_ARG="${@:2}"        # BUTLAST
+: "${POST_PROMPT_ARG:=Summarize:}"
+ARGS=''
 
 if [ -z "$LINK" ]; then
     usage
@@ -65,7 +68,7 @@ function fetch_text() {
 }
 
 LINKS_PRE_PROMPT="Below is a web page article from the specified link address. Follow the instructions after the article."
-SUMMARIZE_POST_PROMPT="Summarize the above web page article from ${LINK} and ignore website header at the start and look for the main article."
-( printf "# Text of link %s\n" "${LINK}"; fetch_text "${LINK}" | ${CAPTURE_COMMAND}; printf "\n# Instructions\n%b\n" "${SUMMARIZE_POST_PROMPT}") | \
+SUMMARIZE_POST_PROMPT="Read the above web page article from ${LINK} and ignore website header at the start and look for the main article."
+( printf "# Text of link %s\n" "${LINK}"; fetch_text "${LINK}" | ${CAPTURE_COMMAND}; printf "\n# Instructions\n%b\n%b" "${SUMMARIZE_POST_PROMPT}" "${POST_PROMPT_ARG}") | \
 "${SCRIPT_DIR}/llm.sh" --long ${ARGS} "${LINKS_PRE_PROMPT}"
 

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -3,6 +3,13 @@
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 CAPTURE_COMMAND="cat"
 
+. "${SCRIPT_DIR}/../via/functions.sh"
+
+function usage() {
+    echo "Usage: $(basename "$0") [--capture-file file] <LINK>|- [llm.sh options]"
+    exit 1
+}
+
 if [ "$1" == "--capture-file" ]; then
     shift
     printf -v CAPTURE_COMMAND "tee %b" "$1"
@@ -12,25 +19,53 @@ fi
 LINK=${1:-}			# LAST
 ARGS=${@:2}			# BUTLAST
 
-. ${SCRIPT_DIR}/../via/functions.sh
-
 if [ -z "$LINK" ]; then
-    echo "Usage: $(basename $0) [--capture-file fn] <LINK> [llm.sh options]"
-    exit 1
+    usage
 fi
 
 if [ "${LINK}" == "-" ]; then
-    LYNX="cat"
+    fetcher="cat"
 elif command -v lynx &> /dev/null; then
-    LYNX="lynx --dump --nolist"
+    fetcher="lynx"
+    fetch_version="$(lynx -version 2>&1 | head -1)"
+    if [[ $fetch_version =~ Lynx\ Version\ ([0-9a-zA-Z.]+) ]]; then
+	fetch_version="Lynx/${BASH_REMATCH[1]}"
+    fi
 elif command -v links &> /dev/null; then
-    LYNX="links -codepage utf-8 -force-html -width 72 -dump"
+    fetcher="links"
+    fetch_version="$(links -version 2>&1 | head -1)"
+    if [[ $fetch_version =~ Links\ ([0-9a-zA-Z.]+) ]]; then
+	fetch_version="Links/${BASH_REMATCH[1]}"
+    fi
 else
     echo "error: NOLINKS"
     exit 1
 fi
 
-SUMMARIZE_SYSTEM_MESSAGE='Summarize the following web page article and ignore website header at the start and look for the main article.'
-export SYSTEM_MESSAGE="${SYSTEM_MESSAGE:-$(printf "%b" "${SUMMARIZE_SYSTEM_MESSAGE}")}"
+if [ -e "${fetch_version}" ]; then
+    log_and_exit 2 "Could not find the Lynx/Links version number."
+fi
 
-${LYNX} "${LINK}" | ${CAPTURE_COMMAND} | ${SCRIPT_DIR}/llm.sh --long ${ARGS} "# Text of link ${LINK}" 
+# until we get it working
+: "${ABUSE_EMAIL_ADDRESS:=klotz@klotz.me}"
+# : "${ABUSE_EMAIL_ADDRESS:=abuse@hallux.ai}"
+: "${SCUTTLE_USER_AGENT:=ScuttleService/1.0 (+https://github.com/hallux-ai/summarizer-service; ${ABUSE_EMAIL_ADDRESS}) ${fetch_version}}"
+: "${SCUTTLE_REFERER:=https://scuttle.klotz.me}"
+
+function fetch_text() {
+    local url="$1"
+    if [ "${fetcher}" == "lynx" ]; then
+	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" -header="Referer: ${SCUTTLE_REFERER}" "${url}"
+    elif [ "${fetcher}" == "links" ]; then
+	links -codepage utf-8 -force-html -width 72 -dump  -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
+    else
+	echo "error: NOLINKS"
+	exit 1
+    fi
+}
+
+LINKS_PRE_PROMPT="Below is a web page article from the specified link address. Follow the instructions after the article."
+SUMMARIZE_POST_PROMPT="Summarize the above web page article from ${LINK} and ignore website header at the start and look for the main article."
+( printf "# Text of link %s\n" "${LINK}"; fetch_text "${LINK}" | ${CAPTURE_COMMAND}; printf "\n# Instructions\n%b\n" "${SUMMARIZE_POST_PROMPT}") | \
+"${SCRIPT_DIR}/llm.sh" --long ${ARGS} "${LINKS_PRE_PROMPT}"
+

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -58,7 +58,8 @@ fi
 function fetch_text() {
     local url="$1"
     if [ "${fetcher}" == "lynx" ]; then
-	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" -header="Referer: ${SCUTTLE_REFERER}" "${url}"
+	# todo: support referer in lynx via -cfg file
+	lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" "${url}"
     elif [ "${fetcher}" == "links" ]; then
 	links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
     else

--- a/via/api/functions.sh
+++ b/via/api/functions.sh
@@ -40,6 +40,8 @@ VIA_API_UNLOAD_MODEL_ENDPOINT="${VIA_API_CHAT_BASE}/v1/internal/model/unload"
 # dolphin-2.7-mixtral: yes
 USE_SYSTEM_ROLE="${USE_SYSTEM_ROLE:-}"
 
+# remove this because it forces a min bound on context
+# max_tokens: 4096, 
 TEMPLATE_SETTINGS="
     mode: \$mode,
     temperature_last: true,
@@ -52,7 +54,7 @@ TEMPLATE_SETTINGS="
     top_k: 40, tfs_z: 1.000, top_p: 0.950, min_p: 0.050, typical_p: 1.000, temp: \$temperature,
     mirostat: 0, mirostat_lr: 0.100, mirostat_ent: 5.000,
     n_keep: 1,
-    max_tokens: 4096, auto_max_new_tokens: true,
+    auto_max_new_tokens: true,
     skip_special_tokens: false"
 
 SYSTEM_ROLE_TEMPLATE="{


### PR DESCRIPTION
scripts/scuttle.sh,scripts/summarize.sh:
   - Updated the usage message to allow `-` as a special argument for stdin input.
   - Enhanced the `fetcher` selection logic to support stdin input directly via `cat` when the argument is `-`.
   - Modified the `fetch_text` function to remove the `referer` option for `lynx` and added a comment to indicate the need for future support via a config file.




