### PR TITLE
Improve model listing and add tests for system message variations

### DIFF
--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 
 # todo: character context for instruct model preset
-LINUX_HELP_SYSTEM_MESSAGE="$(printf "%b" "You are an AI bot designed to assist with various tasks, including answering questions, providing information, and executing commands. You can help you with Linux, Bash, Python, general programming, and other subjects. I'll ask and you do your best to assist you. Our interactions are one-shot, question and response. This is your system message.\n")"
+LINUX_HELP_SYSTEM_MESSAGE="$(printf "%b" "You are an AI bot designed to assist with various tasks, including answering questions, providing information, and executing commands. You can help you with Linux, Bash, Python, general programming, and other subjects. Our interactions are one-shot, question and response. This is your system message.\n")"
 
 #LINUX_HELP_SYSTEM_MESSAGE="$(printf "%b" "Answer the following user question, write the requested code, or follow other user instruction, about Linux, Bash, Python, general programming, or even other subjects, if you know the answer:\n")"
 export SYSTEM_MESSAGE="${SYSTEM_MESSAGE:-${LINUX_HELP_SYSTEM_MESSAGE}}"

--- a/scripts/help.sh
+++ b/scripts/help.sh
@@ -2,10 +2,10 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 
-# todo: character context for chat-instruct model preset
-#LINUX_AIBOT_SYSTEM_MESSAGE="$(printf "%b" "I am an AI bot designed to assist you with various tasks, including answering questions, providing information, and executing commands. I can help you with Linux, Bash, Python, general programming, and other subjects. Just ask and I'll do my best to assist you.\n")"
+# todo: character context for instruct model preset
+LINUX_HELP_SYSTEM_MESSAGE="$(printf "%b" "You are an AI bot designed to assist with various tasks, including answering questions, providing information, and executing commands. You can help you with Linux, Bash, Python, general programming, and other subjects. I'll ask and you do your best to assist you. Our interactions are one-shot, question and response. This is your system message.\n")"
 
-LINUX_HELP_SYSTEM_MESSAGE="$(printf "%b" "Answer the following user question, write the requested code, or follow other user instruction, about Linux, Bash, Python, general programming, or even other subjects, if you know the answer:\n")"
+#LINUX_HELP_SYSTEM_MESSAGE="$(printf "%b" "Answer the following user question, write the requested code, or follow other user instruction, about Linux, Bash, Python, general programming, or even other subjects, if you know the answer:\n")"
 export SYSTEM_MESSAGE="${SYSTEM_MESSAGE:-${LINUX_HELP_SYSTEM_MESSAGE}}"
 
 exec "${SCRIPT_DIR}/llm.sh" "$@"

--- a/scripts/via.sh
+++ b/scripts/via.sh
@@ -9,7 +9,7 @@ status=0
 [ -z "${IN_LLM_SH_ENV}" ] && [ -f "${SCRIPT_DIR}/env.sh" ] && source "${SCRIPT_DIR}/env.sh"
 
 function usage {
-    echo "usage: $(basename "$0") [--via] [api|cli|--api|--cli] [--get-model-name] [--list-models] [--load-model model-name] [--unload-model] [--list-model-types] [--get-via] [--help]" >> /dev/stderr
+    echo "usage: $(basename "$0") [--via] [api|cli|--api|--cli] [--get-model-name] [--list-models [ match words ]] [--load-model model-name] [--unload-model] [--list-model-types] [--get-via] [--help]" >> /dev/stderr
     if [ -n "$1" ];
     then
        echo "       $1" >> /dev/stderr

--- a/scripts/via.sh
+++ b/scripts/via.sh
@@ -62,7 +62,7 @@ function main {
                 break ;;
             --list-models)
                 init_model
-                list_models
+                list_models "${@}"
                 status=$?
                 break ;;
             --list-model-types)

--- a/tests/multihelp.sh
+++ b/tests/multihelp.sh
@@ -5,7 +5,7 @@ VIA_DIRECTORY="$(realpath "${SCRIPT_DIR}/../via")"
 
 source "${VIA_DIRECTORY}/logging.sh"
 
-INFO=1
+INFO=1 log_info "model=$(via --get-model-name)"
 
 export USE_SYSTEM_MESSAGE
 export INFERENCE_MODE
@@ -13,7 +13,7 @@ for USE_SYSTEM_MESSAGE in "" "1"
 do
     for INFERENCE_MODE in chat instruct chat-instruct
     do
-        log_info "sysmsg=$USE_SYSTEM_MESSAGE $INFERENCE_MODE"
+        INFO=1 log_info "sysmsg=$USE_SYSTEM_MESSAGE $INFERENCE_MODE"
         help.sh "$*"
         echo ""
     done

--- a/tests/multihelp.sh
+++ b/tests/multihelp.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
+VIA_DIRECTORY="$(realpath "${SCRIPT_DIR}/../via")"
+
+source "${VIA_DIRECTORY}/logging.sh"
+
+INFO=1
+
+export USE_SYSTEM_MESSAGE
+export INFERENCE_MODE
+for USE_SYSTEM_MESSAGE in "" "1"
+do
+    for INFERENCE_MODE in chat instruct chat-instruct
+    do
+        log_info "sysmsg=$USE_SYSTEM_MESSAGE $INFERENCE_MODE"
+        help.sh "$*"
+        echo ""
+    done
+done

--- a/via/api/functions.sh
+++ b/via/api/functions.sh
@@ -260,48 +260,6 @@ function get_model_name {
     (curl -s "${VIA_API_MODEL_INFO_ENDPOINT}" "${AUTHORIZATION_PARAMS[@]}" | jq -e -r .model_name 2> /dev/null) || echo "gpt"
 }
 
-# function list_models {
-#     # todo: pass in multiple words and then grep for all of those words. the code below is not right.
-#     local args=$@
-# 
-#     if [ -z "$args" ]; then
-#         curl -s "${VIA_API_MODEL_LIST_ENDPOINT}" "${AUTHORIZATION_PARAMS[@]}" | jq -r '.model_names[]'
-#     else
-#         local pattern="$(printf '%s' "$args" | sed -e 's/ /\|/g')"
-#         log_info pattern="${pattern}"
-#         list_models | grep -iE "$pattern"
-#     fi
-# }
-# 
-# function list_models {
-#     local args=$@
-#     local model_list
-#     local pattern
-# 
-#     if [ -z "$args" ]; then
-#         # Fetch model list using curl and handle potential errors
-#         model_list=$(curl -s "${VIA_API_MODEL_LIST_ENDPOINT}" "${AUTHORIZATION_PARAMS[@]}" 2>/dev/null)
-#         if [ $? -ne 0 ]; then
-#             log_error "Failed to retrieve model list from API."
-#             return 1  # Indicate failure
-#         fi
-#         echo "$model_list" | jq -r '.model_names[]'
-#     else
-#         # Construct a grep pattern from the arguments
-#         pattern=$(printf '%s' "$@" | tr ' ' '|') # Use tr for simpler, safer word separation
-#         log_info "List models matching pattern: r'${pattern}'"
-# 
-#         # Fetch model list and grep for the pattern
-#         model_list=$(curl -s "${VIA_API_MODEL_LIST_ENDPOINT}" "${AUTHORIZATION_PARAMS[@]}" 2>/dev/null)
-#         if [ $? -ne 0 ]; then
-#             log_error "Failed to retrieve model list from API."
-#             return 1
-#         fi
-# 
-#         echo "$model_list" | jq -r '.model_names[]' | grep -iE "$pattern"
-#     fi
-# }
-# 
 function list_models {
     local args=$@
 
@@ -322,9 +280,6 @@ function list_models {
         list_models | grep -i $grep_pattern
     fi
 }
-
-
-
 
 function list_model_types() {
     echo any

--- a/via/functions.sh
+++ b/via/functions.sh
@@ -10,83 +10,13 @@ VIA_CLI_FUNCTIONS_PATH="$(realpath "${VIA_DIRECTORY}/cli/functions.sh")"
 VIA_API_FUNCTIONS_PATH="$(realpath "${VIA_DIRECTORY}/api/functions.sh")"
 MODELS_DIRECTORY="$(realpath "${SCRIPT_DIR}/../models")"
 TMPFILES_TO_DELETE=""
-COLOR_RED='\033[1;31m'
-COLOR_YELLOW='\033[1;33m'
-COLOR_GREEN='\033[1;32m'
-COLOR_BLUE='\033[1;36m'
-NOCOLOR='\033[0m'
-
-# RWK: https://gist.github.com/akostadinov/33bb2606afe1b334169dfbf202991d36?permalink_comment_id=4962266#gistcomment-4962266
-function stack_trace() {
-    local status_code="${1}"
-    local -a stack=("Stack trace of error code '${status_code}':")
-    local stack_size=${#FUNCNAME[@]}
-    local -i i
-    local indent="    "
-    # to avoid noise we start with 1 to skip the stack function
-    for (( i = 1; i < stack_size; i++ )); do
-	local func="${FUNCNAME[$i]:-(top level)}"
-	local -i line="${BASH_LINENO[$(( i - 1 ))]}"
-	local src="${BASH_SOURCE[$i]:-(no file)}"
-	stack+=("$indent └ $src:$line ($func)")
-	indent="${indent}    "
-    done
-    (IFS=$'\n'; echo "${stack[*]}")
-}
-
-function log_verbose {
-    local prog="$(basename "$0")"
-    local message="$1"
-    if [ -n "${VERBOSE}" ];
-    then
-	printf "📣 %s: %s\n" "${prog}" "${message}" > /dev/stderr
-    fi
-}
-
-function log_debug {
-    local prog="$(basename "$0")"
-    local message="$1"
-    if [ -n "${DEBUG}" ]; then
-	   printf "🐞 ${COLOR_BLUE}%s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
-    fi
-}
-
-function log_info {
-    local prog="$(basename "$0")"
-    local message="$1"
-    if [ -n "${INFO}" ]; then
-	printf "✅ ${COLOR_GREEN}INFO %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
-    fi
-}
-
-function log_warn {
-    local prog="$(basename "$0")"
-    local code=$1
-    local message="$2"
-    printf "⚠️  ${COLOR_YELLOW}WARN %s (%s):${NOCOLOR} %s\n" "${prog}" "${code}" "${message}" > /dev/stderr
-}
-
-function log_error {
-    local prog="$(basename "$0")"
-    local message="$1"
-    local code=$?
-    printf "❌ ${COLOR_RED}ERROR in %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
-    [ -n "${PRINT_STACK_TRACE}" ] && printf "%s\n" "$(stack_trace $code)" > /dev/stderr
-}
-
-function log_and_exit {
-    local prog="$(basename "$0")"
-    local code="$1"
-    local message="$2"
-    printf "⛔ ${COLOR_RED}ERROR in %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
-    [ -n "${PRINT_STACK_TRACE}" ] && printf "%s\n" "$(stack_trace "$code")" > /dev/stderr
-    [[ "${code}" =~ ^[0-9]+$ ]] && exit "${code}" || exit 1
-}
 
 # Check if the script is being sourced or directly executed
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     log_and_exit 1 "This script is intended to be sourced, not executed directly."
 fi
+
+source "${VIA_DIRECTORY}/logging.sh"
 
 function source_functions {
     local functions_path="$1"
@@ -102,8 +32,6 @@ function source_functions {
 	log_and_exit 3 "* $0: ERROR: Cannot find functions: ${functions_path}"
     fi
 }
-
-k=0
 
 # caller should add result to $TMPFILES_TO_DELETE
 function mktemp_file() {
@@ -132,6 +60,7 @@ function cleanup_temp_files() {
 
     case "${KEEP_PROMPT_TEMP_FILE}" in
         ALL)
+            log_warn "Leaving temporary files: ${TMPFILES_TO_DELETE}"
             true
             ;;
         ERROR|ERRORS)

--- a/via/logging.sh
+++ b/via/logging.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Check if the script is being sourced or directly executed
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    log_and_exit 1 "This script is intended to be sourced, not executed directly."
+fi
+
+COLOR_RED='\033[1;31m'
+COLOR_YELLOW='\033[1;33m'
+COLOR_GREEN='\033[1;32m'
+COLOR_BLUE='\033[1;36m'
+NOCOLOR='\033[0m'
+
+# RWK: https://gist.github.com/akostadinov/33bb2606afe1b334169dfbf202991d36?permalink_comment_id=4962266#gistcomment-4962266
+function stack_trace() {
+    local status_code="${1}"
+    local -a stack=("Stack trace of error code '${status_code}':")
+    local stack_size=${#FUNCNAME[@]}
+    local -i i
+    local indent="    "
+    # to avoid noise we start with 1 to skip the stack function
+    for (( i = 1; i < stack_size; i++ )); do
+	local func="${FUNCNAME[$i]:-(top level)}"
+	local -i line="${BASH_LINENO[$(( i - 1 ))]}"
+	local src="${BASH_SOURCE[$i]:-(no file)}"
+	stack+=("$indent └ $src:$line ($func)")
+	indent="${indent}    "
+    done
+    (IFS=$'\n'; echo "${stack[*]}")
+}
+
+function log_verbose {
+    local prog="$(basename "$0")"
+    local message="$1"
+    if [ -n "${VERBOSE}" ];
+    then
+	printf "📣 %s: %s\n" "${prog}" "${message}" > /dev/stderr
+    fi
+}
+
+function log_debug {
+    local prog="$(basename "$0")"
+    local message="$1"
+    if [ -n "${DEBUG}" ]; then
+	   printf "🐞 ${COLOR_BLUE}%s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+    fi
+}
+
+function log_info {
+    local prog="$(basename "$0")"
+    local message="$1"
+    if [ -n "${INFO}" ]; then
+	printf "✅ ${COLOR_GREEN}INFO %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+    fi
+}
+
+function log_warn {
+    local prog="$(basename "$0")"
+    local code=$1
+    local message="$2"
+    printf "⚠️  ${COLOR_YELLOW}WARN %s (%s):${NOCOLOR} %s\n" "${prog}" "${code}" "${message}" > /dev/stderr
+}
+
+function log_error {
+    local prog="$(basename "$0")"
+    local message="$1"
+    local code=$?
+    printf "❌ ${COLOR_RED}ERROR in %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+    [ -n "${PRINT_STACK_TRACE}" ] && printf "%s\n" "$(stack_trace $code)" > /dev/stderr
+}
+
+function log_and_exit {
+    local prog="$(basename "$0")"
+    local code="$1"
+    local message="$2"
+    printf "⛔ ${COLOR_RED}ERROR in %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+    [ -n "${PRINT_STACK_TRACE}" ] && printf "%s\n" "$(stack_trace "$code")" > /dev/stderr
+    [[ "${code}" =~ ^[0-9]+$ ]] && exit "${code}" || exit 1
+}

--- a/via/logging.sh
+++ b/via/logging.sh
@@ -2,14 +2,15 @@
 
 # Check if the script is being sourced or directly executed
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    log_and_exit 1 "This script is intended to be sourced, not executed directly."
+    echo "This script is intended to be sourced, not executed directly." >> /dev/stderr
+    exit 1
 fi
 
-COLOR_RED='\033[1;31m'
-COLOR_YELLOW='\033[1;33m'
-COLOR_GREEN='\033[1;32m'
-COLOR_BLUE='\033[1;36m'
-NOCOLOR='\033[0m'
+COLOR_RED='\e[1;31m'
+COLOR_YELLOW='\e[1;33m'
+COLOR_GREEN='\e[1;32m'
+COLOR_BLUE='\e[1;36m'
+NOCOLOR='\e[0m'
 
 # RWK: https://gist.github.com/akostadinov/33bb2606afe1b334169dfbf202991d36?permalink_comment_id=4962266#gistcomment-4962266
 function stack_trace() {
@@ -20,21 +21,27 @@ function stack_trace() {
     local indent="    "
     # to avoid noise we start with 1 to skip the stack function
     for (( i = 1; i < stack_size; i++ )); do
-	local func="${FUNCNAME[$i]:-(top level)}"
-	local -i line="${BASH_LINENO[$(( i - 1 ))]}"
-	local src="${BASH_SOURCE[$i]:-(no file)}"
-	stack+=("$indent └ $src:$line ($func)")
-	indent="${indent}    "
+        local func="${FUNCNAME[$i]:-(top level)}"
+        local -i line="${BASH_LINENO[$(( i - 1 ))]}"
+        local src="${BASH_SOURCE[$i]:-(no file)}"
+        stack+=("$indent └ $src:$line ($func)")
+        indent="${indent}    "
     done
     (IFS=$'\n'; echo "${stack[*]}")
+}
+
+function log_with_icon {
+    local icon="$1"
+    local message="$2"
+    local timestamp="$(date -u +"%Y-%m-%d %H:%M:%S.%3NZ")"
+    printf "%s %s %b\n" "${icon}" "${timestamp}" "${message}" > /dev/stderr
 }
 
 function log_verbose {
     local prog="$(basename "$0")"
     local message="$1"
-    if [ -n "${VERBOSE}" ];
-    then
-	printf "📣 %s: %s\n" "${prog}" "${message}" > /dev/stderr
+    if [ -n "${VERBOSE}" ]; then
+        log_with_icon "📣" "${prog}: ${message}"
     fi
 }
 
@@ -42,7 +49,7 @@ function log_debug {
     local prog="$(basename "$0")"
     local message="$1"
     if [ -n "${DEBUG}" ]; then
-	   printf "🐞 ${COLOR_BLUE}%s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+        log_with_icon "🐞" "${COLOR_BLUE}${prog}:${NOCOLOR} ${message}"
     fi
 }
 
@@ -50,7 +57,7 @@ function log_info {
     local prog="$(basename "$0")"
     local message="$1"
     if [ -n "${INFO}" ]; then
-	printf "✅ ${COLOR_GREEN}INFO %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+        log_with_icon "✅" "${COLOR_GREEN}INFO ${prog}:${NOCOLOR} ${message}"
     fi
 }
 
@@ -58,14 +65,14 @@ function log_warn {
     local prog="$(basename "$0")"
     local code=$1
     local message="$2"
-    printf "⚠️  ${COLOR_YELLOW}WARN %s (%s):${NOCOLOR} %s\n" "${prog}" "${code}" "${message}" > /dev/stderr
+    log_with_icon "⚠️" "${COLOR_YELLOW}WARN ${prog} (${code}):${NOCOLOR} ${message}"
 }
 
 function log_error {
     local prog="$(basename "$0")"
     local message="$1"
     local code=$?
-    printf "❌ ${COLOR_RED}ERROR in %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+    log_with_icon "❌" "${COLOR_RED}ERROR in ${prog}:${NOCOLOR} ${message}"
     [ -n "${PRINT_STACK_TRACE}" ] && printf "%s\n" "$(stack_trace $code)" > /dev/stderr
 }
 
@@ -73,7 +80,7 @@ function log_and_exit {
     local prog="$(basename "$0")"
     local code="$1"
     local message="$2"
-    printf "⛔ ${COLOR_RED}ERROR in %s:${NOCOLOR} %s\n" "${prog}" "${message}" > /dev/stderr
+    log_with_icon "⛔" "${COLOR_RED}ERROR in ${prog}:${NOCOLOR} ${message}"
     [ -n "${PRINT_STACK_TRACE}" ] && printf "%s\n" "$(stack_trace "$code")" > /dev/stderr
     [[ "${code}" =~ ^[0-9]+$ ]] && exit "${code}" || exit 1
 }


### PR DESCRIPTION
- Updated help system message variable name and clarified prompt.
- Enhanced `via.sh`'s `list-models` command to accept arguments for filtering model names, improving usability.
- Added `tests/multihelp.sh` to systematically test `help.sh` with different system message and inference mode combinations.
- Improved argument handling in `via/api/functions.sh` for `list_models`, using proper quoting to prevent word splitting.
- Introduced `via/logging.sh` with utilities for standardized and colored logging.
