### PR TITLE
Update environment variables and refactor llm-emacs-helper.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,9 @@ In addition to these command line flags, the script also checks for several envi
 - `VIA`: The type of model runner, `api` or `cli`. Also see `--via` flag.
 - `MODEL_TYPE`: The default model type to use if none is specified via the `-m` or `--model-type` flag. (cli)
 - `TEMPERATURE`: The default temperature parameter for the model if none is specified via the `--temperature` flag.
+  `TOP_K`: TOP_K. Currently only set for api models.
+  `TOP_P`: TOP_P. Currently only set for api models.
+  `MIN_P`: MIN_P. Currently only set for api models.
 - `CONTEXT_LENGTH`: The default context length for the model if none is specified via the `--context-length` or `-c` flag. (cli)
 - `N_PREDICT`: The default number of tokens to predict if none is specified via the `--n-predict` flag.
 - `SYSTEM_MESSAGE`: The default system message to use if none is specified via the command line.

--- a/examples/nvidia-smi.txt
+++ b/examples/nvidia-smi.txt
@@ -1,0 +1,32 @@
+klotz@tensor:~/wip/solon$ nvidia-smi |help.sh explain
+Okay, let's break down what this `nvidia-smi` output is telling us. This is a snapshot of your NVIDIA GPU's status as of May 2nd, 2025. Here’s a detailed explanation:
+
+*   **`NVIDIA-SMI 560.35.05`**:  This indicates you're using NVIDIA System Management Interface version 560.35.05. This is the tool used to query and manage NVIDIA GPUs.
+*   **`Driver Version: 560.35.05` & `CUDA Version: 12.6`**: These are the versions of the NVIDIA driver and the CUDA toolkit installed on your system. CUDA is NVIDIA’s parallel computing platform and API. Version 12.6 suggests you have a relatively recent CUDA installation.
+*   **GPU Information (Row 0)**:
+    *   **`Name: NVIDIA GeForce RTX 3090`**: You have an NVIDIA GeForce RTX 3090 GPU, a high-end graphics card.
+    *   **`Persistence-M: Off`**:  GPU persistence mode is disabled. When enabled, the driver keeps the GPU context loaded even when no applications are actively using it, potentially reducing overhead when relaunching applications.
+    *   **`Bus-Id: 0000:00:00.0`**: This is the PCI bus ID of your GPU – it’s a unique identifier for the card within your system.
+    *   **`Disp.A: Off`**: Display output is currently disabled on this GPU.
+    *   **`Volatile Uncorr. ECC: N/A`**:  Error correction code (ECC) isn't being monitored, or isn't applicable to this GPU configuration.  RTX 3090s don’t typically have ECC enabled by default.
+*   **GPU Usage (Row 0 - continued)**:
+    *   **`Fan: 30%`**:  The GPU fan is running at 30% speed.
+    *   **`Temp: 39C`**: The GPU temperature is 39 degrees Celsius. This is a very cool temperature, indicating good cooling.
+    *   **`Perf: P8`**: Performance state is set to P8. The power limit appears to be controlling the performance.
+    *   **`Pwr:Usage/Cap: 19W / 350W`**: The GPU is currently using 19 Watts of power out of a maximum capacity of 350 Watts.  Very low power draw, suggesting low activity.
+    *   **`Memory-Usage: 23876MiB / 24576MiB`**:  The GPU is using 23876 MiB of its 24576 MiB total memory.  Almost fully utilized.
+    *   **`GPU-Util: 0%`**:  The GPU is currently not performing any computations (0% utilization).
+    *   **`Compute M.: Default`**: The compute mode is set to the default configuration.
+    *   **`MIG M.: N/A`**: Multi-Instance GPU (MIG) isn't being used. MIG allows you to partition the GPU into smaller, isolated instances.
+*   **Processes Section**:
+    *   **`PID: 3952`**: Process ID 3952 is using the GPU.
+    *   **`Type: C`**: The process is a CUDA application.
+    *   **`Process name: ...llama_cpp_binaries/bin/llama-server`**:  The process is `llama-server`, which is a part of the `llama.cpp` project. This indicates you are running a large language model (LLM) inference server.
+    *   **`GPU Memory Usage: 23866MiB`**: This process is consuming 23866 MiB of GPU memory. This confirms `llama-server` is the primary user of the GPU.  The memory usage closely matches the overall GPU memory usage.
+
+**In summary:** You have an RTX 3090 GPU that is currently running `llama-server`, a program used for running LLMs. The GPU is almost fully utilizing its memory, but is currently idle in terms of compute (0% GPU utilization) and is consuming minimal power. The fan is running at a low speed, keeping the temperature very cool.  It appears the LLM is loaded into memory, ready to serve requests, but isn't actively processing anything at this moment.
+
+Do you want me to elaborate on any specific aspect, like the `llama.cpp` project, CUDA, or perhaps how to monitor the GPU utilization over time?
+klotz@tensor:~/wip/solon$ via --get-model-name
+vinimuchulski_gemma-3-27b-it-qat-q4_0-gguf/gemma-3-27b-it-q4_0.gguf
+klotz@tensor:~/wip/solon$

--- a/llm_el/llm-emacs-helper.sh
+++ b/llm_el/llm-emacs-helper.sh
@@ -28,7 +28,7 @@ function reorder_code {
     # Check if a comment sequence is provided, otherwise default to "// "
     comment_seq="${1:-// }"
 
-    awk -v comment_seq="$comment_seq" '
+    gawk -v comment_seq="$comment_seq" '
     BEGIN {
         in_code_fence = 0
         lang = ""
@@ -119,7 +119,7 @@ if [ -z "${result}" ]; then
 fi
 
 if [ -n "$REORDER_CODE" ]; then
-    # todo: move this calculation to emacs since it already has the info
+    # todo: refactor into a function
     case "${MAJOR_MODE}" in
         sh-mode) comment="# " ;;
         *lisp*-mode) comment=";;; " ;;

--- a/llm_el/llm-emacs-helper.sh
+++ b/llm_el/llm-emacs-helper.sh
@@ -1,22 +1,28 @@
 #!/bin/bash
 
+# Script to interact with an LLM for code/text manipulation via Emacs major mode.
+# It accepts a use case, model type, and input (either from stdin or a file) to perform
+# tasks like rewriting, summarizing, completing, or answering questions about the input.
+# It handles context length estimation and optional code reordering with comments.
+
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 LLM_SH="${SCRIPT_DIR}/../scripts/llm.sh"
 : "${DEBUG:=}"
+
+# Enable debugging output if the DEBUG variable is set.
 if [ -n "${DEBUG}" ]; then
     (env; printf "\n%s\n" "${*}")
 fi
 
-# usage: llm-emacs-helper.sh use-case model-type via major-mode WORDS WORDS WORDS
-# usage: llm-emacs-helper.sh use-case model-type via major-mode 'WORDS() `WORDS` WORDS'
-# stdin is region of input
-# e.g. cat foo.sh | ./llm-emacs-helper.sh ask api mixtral bash make this arg parsing better
-# some use cases invert the sense of text and code, changing text to comments and removing code fences.
+# Usage: llm-emacs-helper.sh use-case model-type via major-mode [options] WORDS WORDS WORDS
+# Usage: llm-emacs-helper.sh use-case model-type via major-mode 'WORDS() `WORDS` WORDS'
+# Stdin is the region of input.
+# Example: cat foo.sh | ./llm-emacs-helper.sh ask api mixtral bash make this arg parsing better
+# Some use cases invert the sense of text and code, changing text to comments and removing code fences.
 
 USE_CASE=$1; shift
 VIA=$1; shift
 MODEL_TYPE=$1; shift
-
 
 MAJOR_MODE=""
 PROMPT=""
@@ -24,6 +30,8 @@ RAW_FLAG=""
 N_PREDICT=""
 REORDER_CODE=""
 
+# Function to reorder code by adding a comment sequence before each line, except within code fences.
+# The default comment sequence is "// ", but can be specified as the first argument.
 function reorder_code {
     # Check if a comment sequence is provided, otherwise default to "// "
     comment_seq="${1:-// }"
@@ -51,85 +59,103 @@ function reorder_code {
     '
 }
 
+# Function to calculate the comment prefix based on the major mode.
+function calculate_comment_case {
+    local major_mode="$1"
+    local comment_prefix=""
+
+    case "$major_mode" in
+        sh-mode)      comment_prefix="# "   ;;
+        *lisp*-mode)  comment_prefix=";;; " ;;
+        python*-mode) comment_prefix="# "   ;;
+        c-mode)       comment_prefix="// "  ;;
+        c\+\+-mode)   comment_prefix="// "  ;;
+        *)            comment_prefix="// "  ;;
+    esac
+
+    echo "$comment_prefix"
+}
+
+# Process the use case and set the system message accordingly.
 case "$USE_CASE" in
-    -h) usage
-	exit 0
-	;;
+    -h)
+        usage
+	    exit 0
+	    ;;
     rewrite)
-	# args: major_mode prompt*
-	MAJOR_MODE=$1; shift; PROMPT="${*}"
-	printf -v SYSTEM_MESSAGE "Re-write the following %s according to user instructions:\n" "${MAJOR_MODE}"
+	    # args: major_mode prompt*
+	    MAJOR_MODE=$1; shift; PROMPT="${*}"
+	    printf -v SYSTEM_MESSAGE "Re-write the following %s according to user instructions:\n" "${MAJOR_MODE}"
         REORDER_CODE=1
-	;;
+	    ;;
     
     todo)
-	# args: major_mode prompt*
-	MAJOR_MODE=$1; shift; PROMPT="${*}"
-	printf -v SYSTEM_MESSAGE "Re-write the following %s to address the 'todo' items, following user instructions:\n" "${MAJOR_MODE}"
+	    # args: major_mode prompt*
+	    MAJOR_MODE=$1; shift; PROMPT="${*}"
+	    printf -v SYSTEM_MESSAGE "Re-write the following %s to address the 'todo' items, following user instructions:\n" "${MAJOR_MODE}"
         REORDER_CODE=1
-	;;
+	    ;;
     
     ask)
-	# args: major_mode prompt*
-	MAJOR_MODE=$1; shift; PROMPT="${*}"
-	printf -v SYSTEM_MESSAGE "Answer the user question about the following %s content:\n" "${MAJOR_MODE}"
-	;;
+	    # args: major_mode prompt*
+	    MAJOR_MODE=$1; shift; PROMPT="${*}"
+	    printf -v SYSTEM_MESSAGE "Answer the user question about the following %s content:\n" "${MAJOR_MODE}"
+	    ;;
 
     write)
-	# args: major_mode prompt*
-	MAJOR_MODE=$1; shift; PROMPT="${*}"
-	printf -v SYSTEM_MESSAGE "Write a response according to user instructions and the following %s:\n" "${MAJOR_MODE}"
-	;;
+	    # args: major_mode prompt*
+	    MAJOR_MODE=$1; shift; PROMPT="${*}"
+	    printf -v SYSTEM_MESSAGE "Write a response according to user instructions and the following %s:\n" "${MAJOR_MODE}"
+	    ;;
 
     summarize)
-	# args: major_mode prompt*
-	MAJOR_MODE=$1; shift; PROMPT="${*}"
-	printf -v SYSTEM_MESSAGE "Summarize the following %s:" "${MAJOR_MODE}"
-	;;
+	    # args: major_mode prompt*
+	    MAJOR_MODE=$1; shift; PROMPT="${*}"
+	    printf -v SYSTEM_MESSAGE "Summarize the following %s:" "${MAJOR_MODE}"
+	    ;;
 
     complete)
-	# args: major_mode n_predict prompt*
-	N_PREDICT=$1; shift; PROMPT="${*}"
-	export SYSTEM_MESSAGE="Complete the ${MAJOR_MODE} code:"
-	RAW_FLAG="--raw-input"
-	N_PREDICT="--n-predict ${N_PREDICT}"
-	;;
+	    # args: major_mode n_predict prompt*
+	    N_PREDICT=$1; shift; PROMPT="${*}"
+	    export SYSTEM_MESSAGE="Complete the ${MAJOR_MODE} code:"
+	    RAW_FLAG="--raw-input"
+	    N_PREDICT="--n-predict ${N_PREDICT}"
+	    ;;
 
     *)
-	# args: major_mode prompt*
-	MAJOR_MODE=$1; shift; PROMPT="${*}"
-	printf -v SYSTEM_MESSAGE "Read this following %s and respond to this request:" "${MAJOR_MODE}"
-	;;
+	    # args: major_mode prompt*
+	    MAJOR_MODE=$1; shift; PROMPT="${*}"
+	    printf -v SYSTEM_MESSAGE "Read this following %s and respond to this request:" "${MAJOR_MODE}"
+	    ;;
 esac
 
 export SYSTEM_MESSAGE
 
+# Create a temporary file to store the input.
 INPUT_TEMPFILE=$(mktemp)
 cat >> "${INPUT_TEMPFILE}"
 
-# estimate context length
+# Estimate context length (limited to 2048-32768 characters)
 context_length=$(( $(wc -c < "${INPUT_TEMPFILE}") / 3 ))
 context_length=$((context_length < 2048 ? 2048 : context_length > 32768 ? 32768 : context_length))
-#set -x
 
+# Execute the LLM script and capture the result.
 result="$(cat "${INPUT_TEMPFILE}" | ${LLM_SH} --via "${VIA}" -m "${MODEL_TYPE}" ${DEBUG} --context-length "${context_length}" --stdin ${RAW_FLAG} ${N_PREDICT} "${PROMPT}")"
+
+# If the LLM script returns an empty result, exit with an error.
 if [ -z "${result}" ]; then
     cat "${INPUT_TEMPFILE}"
     exit 1
 fi
 
+# Reorder code with comments if the REORDER_CODE flag is set.
 if [ -n "$REORDER_CODE" ]; then
-    # todo: refactor into a function
-    case "${MAJOR_MODE}" in
-        sh-mode) comment="# " ;;
-        *lisp*-mode) comment=";;; " ;;
-        python*-mode) comment="# " ;;
-        c-mode) comment="// " ;;
-        c\+\+-mode) comment="// " ;;
-        *) comment="// ";;
-    esac
-    printf "%s\n" "${result}" | reorder_code "${comment}"
+    comment_prefix=$(calculate_comment_case "${MAJOR_MODE}")
+    printf "%s\n" "${result}" | reorder_code "${comment_prefix}"
 else
     printf "%s\n" "${result}"
 fi
+
+# Clean up the temporary file.
+# TODO: Do this with a trap
 rm "${INPUT_TEMPFILE}"

--- a/llm_el/llm-emacs-helper.sh
+++ b/llm_el/llm-emacs-helper.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 LLM_SH="${SCRIPT_DIR}/../scripts/llm.sh"
 : "${DEBUG:=}"
 if [ -n "${DEBUG}" ]; then
@@ -11,7 +11,7 @@ fi
 # usage: llm-emacs-helper.sh use-case model-type via major-mode 'WORDS() `WORDS` WORDS'
 # stdin is region of input
 # e.g. cat foo.sh | ./llm-emacs-helper.sh ask api mixtral bash make this arg parsing better
-
+# some use cases invert the sense of text and code, changing text to comments and removing code fences.
 
 USE_CASE=$1; shift
 VIA=$1; shift
@@ -22,6 +22,34 @@ MAJOR_MODE=""
 PROMPT=""
 RAW_FLAG=""
 N_PREDICT=""
+REORDER_CODE=""
+
+function reorder_code {
+    # Check if a comment sequence is provided, otherwise default to "// "
+    comment_seq="${1:-// }"
+
+    awk -v comment_seq="$comment_seq" '
+    BEGIN {
+        in_code_fence = 0
+        lang = ""
+    }
+
+    {
+        if ($0 ~ /^```(.*)$/) {
+            in_code_fence = 1 - in_code_fence
+            if (in_code_fence == 0) {
+                lang = ""
+            } else {
+                lang = gensub(/^```(.*)$/, "\\1", "g")
+            }
+        } else if (in_code_fence == 0) {
+            print comment_seq $0
+        } else {
+            print $0
+        }
+    }
+    '
+}
 
 case "$USE_CASE" in
     -h) usage
@@ -31,12 +59,14 @@ case "$USE_CASE" in
 	# args: major_mode prompt*
 	MAJOR_MODE=$1; shift; PROMPT="${*}"
 	printf -v SYSTEM_MESSAGE "Re-write the following %s according to user instructions:\n" "${MAJOR_MODE}"
+        REORDER_CODE=1
 	;;
     
     todo)
 	# args: major_mode prompt*
 	MAJOR_MODE=$1; shift; PROMPT="${*}"
 	printf -v SYSTEM_MESSAGE "Re-write the following %s to address the 'todo' items, following user instructions:\n" "${MAJOR_MODE}"
+        REORDER_CODE=1
 	;;
     
     ask)
@@ -82,5 +112,24 @@ context_length=$(( $(wc -c < "${INPUT_TEMPFILE}") / 3 ))
 context_length=$((context_length < 2048 ? 2048 : context_length > 32768 ? 32768 : context_length))
 #set -x
 
-cat "${INPUT_TEMPFILE}" | ${LLM_SH} --via ${VIA} -m ${MODEL_TYPE} ${DEBUG} --context-length "${context_length}" --stdin ${RAW_FLAG} ${N_PREDICT} "${PROMPT}" || (cat "${INPUT_TEMPFILE}"; exit 1)
+result="$(cat "${INPUT_TEMPFILE}" | ${LLM_SH} --via "${VIA}" -m "${MODEL_TYPE}" ${DEBUG} --context-length "${context_length}" --stdin ${RAW_FLAG} ${N_PREDICT} "${PROMPT}")"
+if [ -z "${result}" ]; then
+    cat "${INPUT_TEMPFILE}"
+    exit 1
+fi
+
+if [ -n "$REORDER_CODE" ]; then
+    # todo: move this calculation to emacs since it already has the info
+    case "${MAJOR_MODE}" in
+        sh-mode) comment="# " ;;
+        *lisp*-mode) comment=";;; " ;;
+        python*-mode) comment="# " ;;
+        c-mode) comment="// " ;;
+        c\+\+-mode) comment="// " ;;
+        *) comment="// ";;
+    esac
+    printf "%s\n" "${result}" | reorder_code "${comment}"
+else
+    printf "%s\n" "${result}"
+fi
 rm "${INPUT_TEMPFILE}"

--- a/llm_el/llm-emacs-helper.sh
+++ b/llm_el/llm-emacs-helper.sh
@@ -133,6 +133,7 @@ export SYSTEM_MESSAGE
 
 # Create a temporary file to store the input.
 INPUT_TEMPFILE=$(mktemp)
+trap 'rm -f "${INPUT_TEMPFILE}"' EXIT
 cat >> "${INPUT_TEMPFILE}"
 
 # Estimate context length (limited to 2048-32768 characters)
@@ -156,6 +157,5 @@ else
     printf "%s\n" "${result}"
 fi
 
-# Clean up the temporary file.
-# TODO: Do this with a trap
-rm "${INPUT_TEMPFILE}"
+
+

--- a/llm_el/llm.el
+++ b/llm_el/llm.el
@@ -164,7 +164,6 @@ If no region is selected, the function will assume the entire buffer is the regi
    (mapconcat #'(lambda (arg) (shell-quote-argument (format "%s" arg))) args " ")))
 
 ;;; Interface to rewrite.sh
-;      llm-region-internal  x        x   x          x               x           x     x   (current-buffer) t t))
 (defun llm-region-internal (use-case via model-type major-mode-name user-prompt start end output-buffer-name replace-p diff-p)
   "Send the buffer or current region as the output of the llm-rewrite-script-path command based on the prompt and current region and either replaces the region or uses a specified buffer, based on output-buffer-name and replace-p.
 See [shell-command-on-region] for interpretation of output-buffer-name."

--- a/llm_el/llm.el
+++ b/llm_el/llm.el
@@ -38,7 +38,9 @@
 ;;;   - A shell script called 'llm-emacs-helper.sh' that contains the command(s) you want
 ;;;     to run on the buffer or region content.
 
-;;; TODO: make all interactive functions that accept prompt use a `llm-prompt-history` ring
+;;; Configuration
+(defgroup llm nil
+  "Configuration options for the LLM integration." )
 
 (defcustom llm-rewrite-script-path
   "~/wip/llamafiles/llm_el/llm-emacs-helper.sh"
@@ -76,24 +78,37 @@
           (const rocket))
   :group 'llm)
 
-(defvar llm-ask-buffer-name     "*llm-ask*")
-(defvar llm-write-buffer-name   "*llm-write*")
-(defvar llm-summary-buffer-name "*llm-summary*")
-(defvar llm-error-buffer-name   "*llm-errors*")
-(defvar llm-diff-buffer-name    "*llm-diff*")
-(defvar llm-preserve-temp-files nil)
-(defvar llm-git-merge-format "git merge-file -p \"%s\" /dev/null \"%s\"")
+;;; Variables
+(defvar llm-ask-buffer-name     "*llm-ask*"
+  "Name of the buffer to display the LLM ask output.")
 
-;;; User commands
+(defvar llm-write-buffer-name   "*llm-write*"
+  "Name of the buffer to display the LLM write output.")
+
+(defvar llm-summary-buffer-name "*llm-summary*"
+  "Name of the buffer to display the LLM summary output.")
+
+(defvar llm-error-buffer-name   "*llm-errors*"
+  "Name of the buffer to display LLM errors.")
+
+(defvar llm-diff-buffer-name    "*llm-diff*"
+  "Name of the buffer to display LLM diffs.")
+
+(defvar llm-preserve-temp-files nil
+  "Whether to preserve temporary files created during diffing.")
+
+(defvar llm-git-merge-format "git merge-file -p \"%s\" /dev/null \"%s\""
+  "Format string for the git merge command used in diffing.")
+
+;;; User Commands
+
 (defun llm-ask (prompt &optional start end)
   "Writes a new buffer based on the prompt and current region, and the output of the llm-rewrite-script-path command.
 If no region is selected, the function will assume the entire buffer is the region."
   (interactive "sQuestion: \nr")
-  ;; Check if the region is active, if not, use empty string
-  (unless (and start end)
-    (setq start (point-min))
-    (setq end (point-max)))
-  (llm-region-internal "ask" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-ask-buffer-name nil nil))
+  (let ((start (or start (point-min)))
+        (end (or end (point-max))))
+    (llm-region-internal "ask" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-ask-buffer-name nil nil)))
 
 (defun llm-summarize-buffer (user-prompt)
   "Creates a new buffer containing a summary of the current buffer, with a user prompt."
@@ -103,12 +118,10 @@ If no region is selected, the function will assume the entire buffer is the regi
 (defun llm-insert (prompt &optional start end)
   "Insert inferred text based on the prompt and current region in the current buffer."
   (interactive "sPrompt: \nr")
-  ;; Check if the region is active, if not, use empty string
-  (unless (and start end)
-    (setq start (point-min))
-    (setq end (point-max)))
-  (let ((llm-write-buffer-name t))      ;insert into current buffer
-    (llm-region-internal "write" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-write-buffer-name nil nil)))
+  (let ((start (or start (point-min)))
+        (end (or end (point-max))))
+    (let ((llm-write-buffer-name t))      ;insert into current buffer
+      (llm-region-internal "write" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-write-buffer-name nil nil))))
 
 (defun llm-complete (prompt start end)
   "Insert some inferred text based on current region to point in the current buffer."
@@ -120,11 +133,9 @@ If no region is selected, the function will assume the entire buffer is the regi
 (defun llm-write (prompt &optional start end)
   "Writes a new buffer based on the prompt and current region, and the output of the llm-rewrite-script-path command"
   (interactive "sPrompt: \nr")
-  ;; Check if the region is active, if not, use empty string
-  (unless (and start end)
-    (setq start (point-min))
-    (setq end (point-max)))
-  (llm-region-internal "write" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-write-buffer-name nil nil))
+  (let ((start (or start (point-min)))
+        (end (or end (point-max))))
+    (llm-region-internal "write" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-write-buffer-name nil nil)))
 
 (defun llm-rewrite (user-prompt start end)
   "Rewrites the current region with the output of the llm-rewrite-script-path command based on the prompt and current region"
@@ -142,6 +153,7 @@ If no region is selected, the function will assume the entire buffer is the regi
 ;; then uses the output between the last two output boundaries to generate an
 ;; explanation through the llm-ask function.
 (defun llm-explain-output (prompt)
+  "Explains output from comint-mode using LLM.  Prompts for a question, or uses a default."
   (interactive "sQuestion: ")
   (let* ((bounds (my-comint-get-previous-output-bounds))
          (start (car bounds))
@@ -152,31 +164,27 @@ If no region is selected, the function will assume the entire buffer is the regi
                    prompt)))
     (llm-ask prompt start end)))
 
+;;; Internal Functions
+
 (defun llm-infer-command-internal (&rest args)
+  "Constructs the command string for calling the LLM script."
   (concat
    llm-rewrite-script-path
    " "
    (mapconcat #'(lambda (arg) (shell-quote-argument (format "%s" arg))) args " ")))
 
-;;; Interface to rewrite.sh
 (defun llm-region-internal (use-case via model-type major-mode-name user-prompt start end output-buffer-name replace-p diff-p)
-  "Send the buffer or current region as the output of the llm-rewrite-script-path command based on the prompt and current region and either replaces the region or uses a specified buffer, based on output-buffer-name and replace-p.
-See [shell-command-on-region] for interpretation of output-buffer-name."
-  ;; Send the buffer or selected region as a CLI input to 'llm.sh'
-  (let ((start (or start (point-min)))
-        (end (or end (point-max)))
-        (command (llm-infer-command-internal use-case via model-type major-mode-name user-prompt))
-        (display-error-buffer t)
-        (region-noncontiguous-p nil))
-    (message "llm-region-internal: buffer=%s[%s,%s] command=%s replace-p=%s diff-p=%s output-buffer-name=%s" (buffer-name) start end command replace-p diff-p output-buffer-name)
-    (let ((max-mini-window-height 0.0)
-          (output-buffer-name (if replace-p (buffer-name (current-buffer)) output-buffer-name)))
-      (cond ((and replace-p diff-p) (llm-region-as-diff-internal start end command))
-            (t (shell-command-on-region start end command output-buffer-name replace-p
-                                        llm-error-buffer-name display-error-buffer
-                                        region-noncontiguous-p))))))
+  "Sends the buffer or current region as input to 'llm.sh'."
+  (message "llm-region-internal: buffer=%s[%s,%s] command=%s replace-p=%s diff-p=%s output-buffer-name=%s"
+           (buffer-name) start end (llm-infer-command-internal use-case via model-type major-mode-name user-prompt)
+           replace-p diff-p output-buffer-name)
+  (let ((output-buffer-name (if replace-p (buffer-name (current-buffer)) output-buffer-name)))
+    (cond ((and replace-p diff-p) (llm-region-as-diff-internal start end (llm-infer-command-internal use-case via model-type major-mode-name user-prompt)))
+          (t (shell-command-on-region start end (llm-infer-command-internal use-case via model-type major-mode-name user-prompt) output-buffer-name replace-p
+                                        llm-error-buffer-name t nil)))))
 
 (defun llm-region-as-diff-internal (start end command)
+  "Creates a diff between the original region and the LLM-generated text."
   (let* ((original-string (buffer-substring start end))
          (llm-output (with-temp-buffer
                        (insert original-string)
@@ -212,24 +220,20 @@ See [shell-command-on-region] for interpretation of output-buffer-name."
     (delete-file temp-file-after)))
 
 (defun llm-complete-internal (prompt via model-type start end n-predict)
-  ;; Send the buffer or selected region as a CLI input to 'llm.sh'
-  (let* ((command (llm-infer-command-internal "complete" via model-type (llm-mode-text-type) n-predict prompt))
-         (display-error-buffer t)
-         (region-noncontiguous-p nil))
-    (message "llm-commplete-internal: %s" command)
-    (let ((max-mini-window-height 0.0)
-          (old-text (buffer-substring start end))
-          (new-end))
-      ;; todo: better prompting, put point at end, leave in place for repeated application, temperature, etc
-      (shell-command-on-region start end command nil t llm-error-buffer-name display-error-buffer region-noncontiguous-p)
+  "Completes text based on the current region using the LLM."
+  (let ((command (llm-infer-command-internal "complete" via model-type (llm-mode-text-type) n-predict prompt)))
+    (message "llm-complete-internal: %s" command)
+    (let ((old-text (buffer-substring start end)))
+      (shell-command-on-region start end command nil t llm-error-buffer-name t nil)
       (goto-char start)
       (insert old-text))))
 
 (defun llm-mode-text-type ()
+  "Returns the name of the current major mode."
   (symbol-name major-mode))
 
 (defun llm-load-model ()
-  "Load the specified model using LLM script."
+  "Loads the specified model using the LLM script."
   (interactive)
   (let* ((model-names (with-temp-buffer
                         (when (call-process llm-via-script-path nil t nil "--api" "--list-models")
@@ -242,7 +246,6 @@ See [shell-command-on-region] for interpretation of output-buffer-name."
                (split-string (buffer-string) "\n" t))))
         (message "model-name=%s results=%s" model-name results)))))
 
-;;; these probably belong elsewhere
 (defun my-comint-get-previous-output ()
   "Return the output of the previous shell command in comint mode."
   (interactive)
@@ -260,7 +263,7 @@ See [shell-command-on-region] for interpretation of output-buffer-name."
         (end (point-max)))
     (list start end)))
 
-;; todo: not working
+;;; Not yet implemented: Query Replace
 (defun llm-query-replace (regex prompt)
   "Query replace occurrences matching REGEX with text generated by LLM using PROMPT.
 
@@ -355,4 +358,3 @@ Variable-name is completed from the list of defined Emacs Lisp variables."
 (add-hook 'smerge-mode-hook 'llm-smerge-mode-hook)
 
 (provide 'llm)
-

--- a/llm_el/llm.el
+++ b/llm_el/llm.el
@@ -19,7 +19,7 @@
 ;;;
 ;;; Summary:
 ;;; This package provides functions for summarizing and rewriting the contents
-;;; of Emacs buffers using an external script called 'llm.sh'. The package
+;;; of Emacs buffers using an external script called 'llm-emacs-helper.sh'. The package
 ;;; includes the following functions:
 ;;;   - M-X llm-summarize-buffer
 ;;;     Summarizes the contents of the current buffer in a new buffer.
@@ -125,11 +125,6 @@ If no region is selected, the function will assume the entire buffer is the regi
     (setq start (point-min))
     (setq end (point-max)))
   (llm-region-internal "write" llm-default-via llm-default-model-type (llm-mode-text-type) prompt start end llm-write-buffer-name nil nil))
-
-(defun llm-rewrite (user-prompt start end)
-  "Rewrites the current region with the output of the llm-rewrite-script-path command based on the prompt and current region"
-  (interactive "sRewrite Prompt: \nr")
-  (llm-region-internal "rewrite" llm-default-via llm-default-model-type (llm-mode-text-type) user-prompt start end nil t t))
 
 (defun llm-rewrite (user-prompt start end)
   "Rewrites the current region with the output of the llm-rewrite-script-path command based on the prompt and current region"

--- a/llm_el/llm.el
+++ b/llm_el/llm.el
@@ -221,7 +221,8 @@ If no region is selected, the function will assume the entire buffer is the regi
 
 (defun llm-complete-internal (prompt via model-type start end n-predict)
   "Completes text based on the current region using the LLM."
-  (let ((command (llm-infer-command-internal "complete" via model-type (llm-mode-text-type) n-predict prompt)))
+  (let* ((use-case "complete")
+         (command (llm-infer-command-internal use-case via model-type "--n-predict" n-predict (llm-mode-text-type) prompt)))
     (message "llm-complete-internal: %s" command)
     (let ((old-text (buffer-substring start end)))
       (shell-command-on-region start end command nil t llm-error-buffer-name t nil)

--- a/llm_el/llm.el
+++ b/llm_el/llm.el
@@ -138,7 +138,7 @@ If no region is selected, the function will assume the entire buffer is the regi
 
 (defun llm-todo (user-prompt start end)
   "Rewrites the current region to process 'todo' items with the output of the llm-rewrite-script-path command based on the prompt and current region"
-  (interactive "sRewrite Prompt: \nr")
+  (interactive "sTodo Prompt: \nr")
   (llm-region-internal "todo" llm-default-via llm-default-model-type (llm-mode-text-type) user-prompt start end nil t t))
 
 ;; This function is used in comint-mode to understand and explain the output in an
@@ -207,15 +207,11 @@ See [shell-command-on-region] for interpretation of output-buffer-name."
       (insert new-string))
 
     ;; Run the diff command and capture the output in the *llm-diff* buffer
-    (with-current-buffer diff-buffer
-      (erase-buffer)
-      (insert (shell-command-to-string diff-command))
-      (smerge-mode)
-      (diff-auto-refine-mode 1)
-      (goto-char (point-min))))
-  (delete-region start end)
-  (goto-char start)
-  (insert new-string)
+    (delete-region start end)
+    (goto-char start)
+    (insert (shell-command-to-string diff-command))
+    (smerge-mode)
+    (diff-auto-refine-mode 1))
 
   (unless llm-preserve-temp-files
     (delete-file temp-file-before)

--- a/scripts/chatlogcat.sh
+++ b/scripts/chatlogcat.sh
@@ -12,9 +12,9 @@
 
 # Usage function
 usage() {
-  echo "Usage: $0 <log_file> [--internal]"
+  echo "Usage: $0 <log_file> [-i]"
   echo "  <log_file>: Path to the logcat JSON file."
-  echo "  --internal: Use '.internal' instead of '.visible' in the JQ selector."
+  echo "  -i: Use '.internal' instead of '.visible' in the JQ selector."
   exit 1
 }
 

--- a/via/api/functions.sh
+++ b/via/api/functions.sh
@@ -63,7 +63,7 @@ else
     seed: \$seed,
     repetition_penalty: \$repetition_penalty,
     repeat_last_n: 64, repeat_penalty: 1.000, frequency_penalty: 0.000, presence_penalty: 0.000,
-    top_k: 40, tfs_z: 1.000, top_p: 0.950, min_p: 0.050, typical_p: 1.000,
+    top_k: 20, tfs_z: 1.000, top_p: 0.950, min_p: 0, typical_p: 1.000,
     mirostat: 0, mirostat_lr: 0.100, mirostat_ent: 5.000,
     n_keep: 1,
     auto_max_new_tokens: true,

--- a/via/api/functions.sh
+++ b/via/api/functions.sh
@@ -4,7 +4,7 @@
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]];
 then
     echo "This script '${BASH_SOURCE[0]}' is intended to be sourced, not executed directly."
-    exit 1
+#    exit 1
 fi
 
 : "${VIA_API_CHAT_BASE:=http://localhost:5000}"
@@ -22,6 +22,9 @@ AUTHORIZATION_PARAMS=()
 
 # TODO: sampling order:  CFG -> Penalties -> top_k -> tfs_z -> typical_p -> top_p -> min_p -> temperature
 # todo: Sampling order appears to be a key differentiator for results from llamafile vs ooba but it's ununnvestigagted
+TOP_K="${TOP_K:-20}"
+TOP_P="${TOP_P:-0.95}"
+MIN_P="${MIN_P:-0.1}"
 
 # --grammar-file support is spotty in non-gguf models so default to off
 : "${VIA_API_USE_GRAMMAR:=}"
@@ -63,7 +66,7 @@ else
     seed: \$seed,
     repetition_penalty: \$repetition_penalty,
     repeat_last_n: 64, repeat_penalty: 1.000, frequency_penalty: 0.000, presence_penalty: 0.000,
-    top_k: 20, tfs_z: 1.000, top_p: 0.950, min_p: 0, typical_p: 1.000,
+    top_k: ${TOP_K}, tfs_z: 1.000, top_p: ${TOP_P}, min_p: ${MIN_P}, typical_p: 1.000,
     mirostat: 0, mirostat_lr: 0.100, mirostat_ent: 5.000,
     n_keep: 1,
     auto_max_new_tokens: true,

--- a/via/cli/functions.sh
+++ b/via/cli/functions.sh
@@ -200,6 +200,7 @@ function cli_perform_inference {
     if [ -n "${GRAMMAR_FILE}" ]; then
 	GRAMMAR_FILE="--grammar-file ${GRAMMAR_FILE}"
     fi
+    # TODO: add TOP_P TOP_K MIN_P from global env, skipping if not set.
     # set -x
     cat "${PROMPT_TEMP_FILE}" | fixup_input | ${MODEL_RUNNER} "${MODEL_PATH}" --cli ${LOG_DISABLE} ${GPU} ${NGL} ${GRAMMAR_FILE} ${TEMPERATURE} ${CONTEXT_LENGTH} ${N_PREDICT} ${BATCH_SIZE} ${NO_PENALIZE_NL} --repeat-penalty 1 ${THREADS} -f /dev/stdin ${SILENT_PROMPT} --seed "${SEED}" ${LLM_ADDITIONAL_ARGS} | fixup_output 2> "${ERROR_OUTPUT}"
     return $?


### PR DESCRIPTION
This commit introduces new environment variables TOP_K, TOP_P, and MIN_P to control sampling parameters for the LLM API.

The llm-emacs-helper.sh script has been significantly refactored to improve argument parsing, add code reordering functionality for better formatting, enhance debug output, and handle edge cases more gracefully.  The corresponding Emacs Lisp code (llm.el) has been updated to align with these changes.  Minor updates to scuttle.sh and summarize.sh improve error handling for web page retrieval. The via/api/functions.sh file has been updated to include TOP_K, TOP_P, and MIN_P parameters.

- Added TOP_K, TOP_P, MIN_P environment variables.
- Refactored llm-emacs-helper.sh for improved robustness and functionality.
- Updated llm.el to reflect changes in llm-emacs-helper.sh.
- Added examples/nvidia-smi.txt for debugging.
- Improved error handling in scuttle.sh and summarize.sh
- Updated via/api/functions.sh to include new variables