### PR TITLE
downlink: Add webpage fetching and Markdown conversion capabilities

### DIFF
--- a/examples/help-history.txt
+++ b/examples/help-history.txt
@@ -1,0 +1,3 @@
+$ history|tail -100 | help.sh what was i doing
+
+Based on the command history provided, it seems that you were working on a script called `downlink.py` to fetch and convert webpages to Markdown, and another script called `summarize.sh` to summarize webpages. You were also working on setting up a virtual environment, installing necessary Python packages like `requests_html`, `markdownify`, and `lxml_html_clean`, and updating your `requirements.txt` file. Additionally, you were experimenting with different tools to view Markdown files, such as `glow`, and were making changes to your Git repository, including resolving merge conflicts and pushing your changes.

--- a/llm_el/llm.el
+++ b/llm_el/llm.el
@@ -213,11 +213,11 @@ If no region is selected, the function will assume the entire buffer is the regi
     (goto-char start)
     (insert (shell-command-to-string diff-command))
     (smerge-mode)
-    (diff-auto-refine-mode 1))
+    (diff-auto-refine-mode 1)
 
-  (unless llm-preserve-temp-files
-    (delete-file temp-file-before)
-    (delete-file temp-file-after)))
+    (unless llm-preserve-temp-files
+      (delete-file temp-file-before)
+      (delete-file temp-file-after))))
 
 (defun llm-complete-internal (prompt via model-type start end n-predict)
   "Completes text based on the current region using the LLM."

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,1 +1,2 @@
 env.sh
+.venv

--- a/scripts/downlink.py
+++ b/scripts/downlink.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# pip install requests-html markdownify
+# See https://medium.com/@tubelwj/requests-html-an-html-parsing-library-in-python-8d182d13ecd2
+# Qwen2.5-Coder-32B-Instruct-Q5_K_S.gguf
+
+import argparse
+from requests_html import HTMLSession
+from markdownify import markdownify as md
+
+def fetch_and_convert_to_markdown(url):
+    session = HTMLSession()
+    response = session.get(url)
+    
+    if response.status_code != 200:
+        print(f"Failed to fetch the URL. Status code: {response.status_code}")
+        return None
+    
+    # Render JavaScript if necessary
+    response.html.render(timeout=16000)
+    
+    # Convert HTML to Markdown
+    markdown_text = md(response.html.html)
+    return markdown_text
+
+def main():
+    parser = argparse.ArgumentParser(description="Convert a webpage to Markdown.")
+    parser.add_argument("url", type=str, help="The URL of the webpage to convert.")
+    
+    args = parser.parse_args()
+    
+    markdown_text = fetch_and_convert_to_markdown(args.url)
+    if markdown_text:
+        print(markdown_text)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/downlink.py
+++ b/scripts/downlink.py
@@ -8,9 +8,10 @@ import argparse
 from requests_html import HTMLSession
 from markdownify import markdownify as md
 
-def fetch_and_convert_to_markdown(url):
+def fetch_and_convert_to_markdown(url, user_agent):
     session = HTMLSession()
-    response = session.get(url)
+    headers = { 'user-agent': user_agent }
+    response = session.get(url, headers=headers)
     
     if response.status_code != 200:
         print(f"Failed to fetch the URL. Status code: {response.status_code}")
@@ -26,10 +27,11 @@ def fetch_and_convert_to_markdown(url):
 def main():
     parser = argparse.ArgumentParser(description="Convert a webpage to Markdown.")
     parser.add_argument("url", type=str, help="The URL of the webpage to convert.")
+    parser.add_argument("--user-agent", type=str, help="Optional User Agent header to send.")
     
     args = parser.parse_args()
     
-    markdown_text = fetch_and_convert_to_markdown(args.url)
+    markdown_text = fetch_and_convert_to_markdown(args.url, args.user_agent)
     if markdown_text:
         print(markdown_text)
 

--- a/scripts/downlink.py
+++ b/scripts/downlink.py
@@ -4,13 +4,16 @@
 # See https://medium.com/@tubelwj/requests-html-an-html-parsing-library-in-python-8d182d13ecd2
 # Qwen2.5-Coder-32B-Instruct-Q5_K_S.gguf
 
+import os
 import argparse
 from requests_html import HTMLSession
 from markdownify import markdownify as md
 
+USER_AGENT = """Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"""
+
 def fetch_and_convert_to_markdown(url, user_agent):
-    session = HTMLSession()
-    headers = { 'user-agent': user_agent }
+    session = HTMLSession(browser_args=[f"""--user-agent='{user_agent}'"""])
+    headers = { 'User-Agent': user_agent }
     response = session.get(url, headers=headers)
     
     if response.status_code != 200:
@@ -31,7 +34,10 @@ def main():
     
     args = parser.parse_args()
     
-    markdown_text = fetch_and_convert_to_markdown(args.url, args.user_agent)
+    user_agent = args.user_agent or os.getenv("USER_AGENT", None) or USER_AGENT
+
+    markdown_text = fetch_and_convert_to_markdown(args.url, user_agent)
+
     if markdown_text:
         print(markdown_text)
 

--- a/scripts/fetcher.sh
+++ b/scripts/fetcher.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# fetcher.sh - Fetches content from a URL using available tools
+
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
+. "${SCRIPT_DIR}/../via/functions.sh"
+
+USER_AGENT_TEMPLATE="ScuttleService/1.0 (+https://github.com/hallux-ai/summarizer-service; %s) %s"
+REFERER="https://scuttle.klotz.me"
+# abuse@hallux.ai
+ABUSE_EMAIL_ADDRESS="${ABUSE_EMAIL_ADDRESS:-klotz@klotz.me}"
+: "${FETCHER:=}"   # downlink, links, lynx
+
+usage() {
+    echo "Usage: $(basename "$0") <URL>"
+    exit 1
+}
+
+if [ -z "$1" ]; then
+    usage
+fi
+
+URL="$1"
+DOWNLINK_COMMAND="${SCRIPT_DIR}/downlink.py"
+
+if [ -f "${SCRIPT_DIR}/.venv/bin/activate" ]; then
+    . "${SCRIPT_DIR}/.venv/bin/activate"
+fi
+
+if [ -n "${FETCHER}" ]; then
+    true
+elif [ -x "${DOWNLINK_COMMAND}" ]; then
+    FETCHER="downlink"
+elif command -v lynx &> /dev/null; then
+    FETCHER="lynx"
+    fetch_version="$(lynx -version 2>&1 | head -1)"
+    if [[ $fetch_version =~ Lynx\ Version\ ([0-9a-zA-Z.]+) ]]; then
+        fetch_version="Lynx/${BASH_REMATCH[1]}"
+    fi
+elif command -v links &> /dev/null; then
+    FETCHER="links"
+    fetch_version="$(links -version 2>&1 | head -1)"
+    if [[ $fetch_version =~ Links\ ([0-9a-zA-Z.]+) ]]; then
+        fetch_version="Links/${BASH_REMATCH[1]}"
+    fi
+else
+    echo "error: NOLINKS"
+    exit 1
+fi
+
+USER_AGENT=$(printf "$USER_AGENT_TEMPLATE" "$ABUSE_EMAIL_ADDRESS" "$fetch_version")
+
+if [ -e "${fetch_version}" ]; then
+    echo "Could not find the Lynx/Links version number."
+    exit 1
+fi
+
+log_info "${FETCHER} fetching <${URL}>"
+case "${FETCHER}" in
+    downlink)
+        "${DOWNLINK_COMMAND}" "${URL}" --user-agent "${USER_AGENT}"
+        ;;
+    lynx)
+        lynx --dump --nolist -useragent="${USER_AGENT}" "${URL}"
+        ;;
+    links)
+        links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${USER_AGENT}" -http.fake-referer "${REFERER}" "${URL}"
+        ;;
+    *)
+        log_and_exit "NOLINKS: FETCHER=$FETCHER"
+        exit 1
+        ;;
+esac
+

--- a/scripts/fetcher.sh
+++ b/scripts/fetcher.sh
@@ -5,22 +5,23 @@
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 . "${SCRIPT_DIR}/../via/functions.sh"
 
-USER_AGENT_TEMPLATE="ScuttleService/1.0 (+https://github.com/hallux-ai/summarizer-service; %s) %s"
-REFERER="https://scuttle.klotz.me"
-# abuse@hallux.ai
-ABUSE_EMAIL_ADDRESS="${ABUSE_EMAIL_ADDRESS:-klotz@klotz.me}"
+DEFAULT_USER_AGENT='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'
+USER_AGENT="${USER_AGENT:-${DEFAULT_USER_AGENT}}"
+REFERER="https://scuttle.klotz.me" # abuse@hallux.ai
 : "${FETCHER:=}"   # downlink, links, lynx
 
 usage() {
     echo "Usage: $(basename "$0") <URL>"
+    echo 'Obeys $USER_AGENT'
     exit 1
 }
 
-if [ -z "$1" ]; then
+URL="$1"
+
+if [ -z "$URL" ]; then
     usage
 fi
 
-URL="$1"
 DOWNLINK_COMMAND="${SCRIPT_DIR}/downlink.py"
 
 if [ -f "${SCRIPT_DIR}/.venv/bin/activate" ]; then
@@ -48,7 +49,7 @@ else
     exit 1
 fi
 
-USER_AGENT=$(printf "$USER_AGENT_TEMPLATE" "$ABUSE_EMAIL_ADDRESS" "$fetch_version")
+
 
 if [ -e "${fetch_version}" ]; then
     echo "Could not find the Lynx/Links version number."
@@ -58,7 +59,11 @@ fi
 log_info "${FETCHER} fetching <${URL}>"
 case "${FETCHER}" in
     downlink)
-        "${DOWNLINK_COMMAND}" "${URL}" --user-agent "${USER_AGENT}"
+        if [ -z "${USER_AGENT}" ]; then
+            "${DOWNLINK_COMMAND}" "${URL}"
+        else
+            "${DOWNLINK_COMMAND}" "${URL}" --user-agent "${USER_AGENT}"
+        fi
         ;;
     lynx)
         lynx --dump --nolist -useragent="${USER_AGENT}" "${URL}"
@@ -71,4 +76,3 @@ case "${FETCHER}" in
         exit 1
         ;;
 esac
-

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -38,3 +38,8 @@ for file in ${SH_FILES}
 do
     lnf "${SCRIPT_DIR}/${file}" "${DEST_DIR}/${file}"
 done
+
+cd "${SCRIPT_DIR}"
+python3 -m venv .venv
+. .venv/bin/activate
+pip3 install -r requirements.txt

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,1 +1,3 @@
-requests_html markdownify lxml_html_clean
+requests_html
+markdownify
+lxml_html_clean

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,1 @@
+requests_html markdownify lxml_html_clean

--- a/scripts/scuttle.sh
+++ b/scripts/scuttle.sh
@@ -13,7 +13,7 @@ elif command -v "jq" >/dev/null 2>&1; then
     JQYQ="jq"
     INTERMEDIATE_FORMAT="json"
 else
-    log_error "Error: cannot find jq or yq"
+    log_error 'Error: cannot find jq or yq: do `pip install yq` and do not use yq snap'
     exit 1
 fi
 

--- a/scripts/scuttle.sh
+++ b/scripts/scuttle.sh
@@ -2,18 +2,9 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 CAPTURE_COMMAND="cat"
+FETCHER_COMMAND="${SCRIPT_DIR}/fetcher.sh"
 
 . "${SCRIPT_DIR}/../via/functions.sh"
-
-: "${ABUSE_EMAIL_ADDRESS:=klotz@klotz.me}"
-# : "${ABUSE_EMAIL_ADDRESS:=abuse@hallux.ai}"
-: "${SCUTTLE_USER_AGENT:=ScuttleService/1.0 (+https://github.com/hallux-ai/summarizer-service; ${ABUSE_EMAIL_ADDRESS}) ${fetch_version}}"
-: "${SCUTTLE_REFERER:=https://scuttle.klotz.me}"
-
-function usage() {
-    echo "Usage: $(basename "$0") [--json | --yaml | --link] [--capture-file file] <LINK>|- [llm.sh options]\nCode: $1"
-    exit 1
-}
 
 if command -v "yq" >/dev/null 2>&1; then
     JQYQ="yq"
@@ -70,47 +61,11 @@ if [ -z "$LINK" ]; then
     usage "NOLINK"
 fi
 
-if [ "${LINK}" == "-" ]; then
-    fetcher="cat"
-elif command -v lynx &> /dev/null; then
-    fetcher="lynx"
-    fetch_version="$(lynx -version 2>&1 | head -1)"
-    if [[ $fetch_version =~ Lynx\ Version\ ([0-9a-zA-Z.]+) ]]; then
-        fetch_version="Lynx/${BASH_REMATCH[1]}"
-    fi
-elif command -v links &> /dev/null; then
-    fetcher="links"
-    fetch_version="$(links -version 2>&1 | head -1)"
-    if [[ $fetch_version =~ Links\ ([0-9a-zA-Z.]+) ]]; then
-        fetch_version="Links/${BASH_REMATCH[1]}"
-    fi
-else
-    log_and_exit 1 "error: NOLINKS"
-fi
-
-if [ -e "${fetch_version}" ]; then
-    log_and_exit 2 "Could not find the Lynx/Links version number."
-fi
-
-function fetch_text() {
-    local url="$1"
-    if [ "${fetcher}" == "lynx" ]; then
-        # todo: support referer in lynx via -cfg file
-        # todo: lynx complains about -useragent by design so redirect errors
-        lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" "${url}" 2> /dev/null
-    elif [ "${fetcher}" == "links" ]; then
-        links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
-    else
-        log_and_exit 3 "error: NOLINKS: fetcher=$fetcher"
-        exit 3
-    fi
-}
-
 function extract_output() {
     case "$OUTPUT_MODE" in
         "JSON")
             # awk out just the JSON '{}' objects.
-            awk '/{/{f=1} f; /}/{f=0}' 
+            awk '/{/{f=1} f; /}/{f=0}'
             ;;
         "YAML")
             cat
@@ -123,23 +78,6 @@ function extract_output() {
             ;;
     esac
 }
-
-# # transforms JSON output from LLM into a properly formatted URL string for Scuttle bookmark adding.
-# function scuttle_extract() {
-#     if [ "${OUTPUT_MODE}" == 'YAML' ]; then
-#         cat | remove_code_fence | replace_smart_quotes
-#         return $?
-#     elif [ "${OUTPUT_MODE}" == 'JSON' ]; then
-#         INTERMEDIATE_FORMAT='JSON'
-#         cat | remove_code_fence | replace_smart_quotes
-#         return $?
-#     elif [ "${OUTPUT_MODE}" == 'LINK' ]; then
-#         cat | remove_code_fence | replace_smart_quotes | to_link
-#         return $?
-#     else
-#         usage xxx
-#     fi
-# }
 
 function to_link() {
     # <https://scuttle.klotz.me/bookmarks/klotz?action=add&address=https://example.com&title=Example+Website+&description=This+is+an+example+website&tags=example,website,canonical+page>
@@ -176,7 +114,7 @@ POST_PROMPT_ARG="Respond with only a short ${INTERMEDIATE_FORMAT} object with th
 LINKS_PRE_PROMPT="Below is a web page article from the specified link address. If retrieval failed, report on the failure. Otherwise, follow the instructions after the article."
 SCUTTLE_POST_PROMPT="Read the above web page article from ${LINK} and ignore website header at the start and look for the main article. If there are retrieval failures, just report on the failures."
 
-( printf "# Text of link %s\n" "${LINK}"; fetch_text "${LINK}" | ${CAPTURE_COMMAND}; \
+( printf "# Text of link %s\n" "${LINK}"; "${FETCHER_COMMAND}" "${LINK}" | ${CAPTURE_COMMAND}; \
   printf "\n# Instructions\n%b\n%b\n" "${SCUTTLE_POST_PROMPT}" "${POST_PROMPT_ARG}" ) | \
     "${SCRIPT_DIR}/llm.sh" --long ${GRAMMAR_FLAG} ${ARGS} "${LINKS_PRE_PROMPT}" | \
     postprocess

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -5,7 +5,9 @@ CAPTURE_COMMAND="cat"
 DOWNLINK_COMMAND="${SCRIPT_DIR}/downlink.py"
 
 . "${SCRIPT_DIR}/../via/functions.sh"
-. "${SCRIPT_DIR}/.venv/bin/activate"
+if [ -f . "${SCRIPT_DIR}/.venv/bin/activate" ]; then
+    . "${SCRIPT_DIR}/.venv/bin/activate"
+fi
 
 function usage() {
     echo "Usage: $(basename "$0") [--capture-file file] <LINK>|- [llm.sh options]"

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -19,7 +19,7 @@ if [ "$1" == "--capture-file" ]; then
 fi
 
 LINK=${1:-}                     # LAST
-# todo: actually everything up to a '--' should go into POST_PROMPT and everything after '--' should go into the ARGS.
+# future todo: actually everything up to a '--' should go into POST_PROMPT and everything after '--' should go into the ARGS.
 POST_PROMPT_ARG="${@:2}"        # BUTLAST
 : "${POST_PROMPT_ARG:=Summarize:}"
 ARGS=''
@@ -56,19 +56,21 @@ fi
 # until we get it working
 : "${ABUSE_EMAIL_ADDRESS:=klotz@klotz.me}"
 # : "${ABUSE_EMAIL_ADDRESS:=abuse@hallux.ai}"
-: "${SCUTTLE_USER_AGENT:=ScuttleService/1.0 (+https://github.com/hallux-ai/summarizer-service; ${ABUSE_EMAIL_ADDRESS}) ${fetch_version}}"
-: "${SCUTTLE_REFERER:=https://scuttle.klotz.me}"
+: "${USER_AGENT:=ScuttleService/1.0 (+https://github.com/hallux-ai/summarizer-service; ${ABUSE_EMAIL_ADDRESS}) ${fetch_version}}"
+: "${REFERER:=https://scuttle.klotz.me}"
 
 function fetch_text() {
     local url="$1"
     echo "${fetcher}" "${DOWNLINK_COMMAND}"
     if [ "${fetcher}" == "${DOWNLINK_COMMAND}" ]; then
-        "${DOWNLINK_COMMAND}" "${url}"
+        "${DOWNLINK_COMMAND}" "${url}" --user-agent "${USER_AGENT}"
     elif [ "${fetcher}" == "lynx" ]; then
         # todo: support referer in lynx via -cfg file
-        lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" "${url}"
+        exit 55
+        lynx --dump --nolist -useragent="${USER_AGENT}" "${url}"
     elif [ "${fetcher}" == "links" ]; then
-        links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${SCUTTLE_USER_AGENT}" -http.fake-referer "${SCUTTLE_REFERER}" "${url}"
+        exit 66
+        links -codepage utf-8 -force-html -width 72 -dump -http.fake-user-agent "${USER_AGENT}" -http.fake-referer "${REFERER}" "${url}"
     else
         echo "error: NOLINKS: fetcher=$fetcher"
         exit 1

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
-FETCHER_COMMAND="${SCRIPT_DIR}/fetch.sh"
+FETCHER_COMMAND="${SCRIPT_DIR}/fetcher.sh"
 CAPTURE_COMMAND="cat"
 
 . "${SCRIPT_DIR}/../via/functions.sh"

--- a/scripts/summarize.sh
+++ b/scripts/summarize.sh
@@ -2,8 +2,10 @@
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 CAPTURE_COMMAND="cat"
+DOWNLINK_COMMAND="${SCRIPT_DIR}/downlink.py"
 
 . "${SCRIPT_DIR}/../via/functions.sh"
+. "${SCRIPT_DIR}/.venv/bin/activate"
 
 function usage() {
     echo "Usage: $(basename "$0") [--capture-file file] <LINK>|- [llm.sh options]"
@@ -28,6 +30,8 @@ fi
 
 if [ "${LINK}" == "-" ]; then
     fetcher="cat"
+elif [ -x ${DOWNLINK_COMMAND} ]; then
+    fetcher="${DOWNLINK_COMMAND}"
 elif command -v lynx &> /dev/null; then
     fetcher="lynx"
     fetch_version="$(lynx -version 2>&1 | head -1)"
@@ -57,7 +61,10 @@ fi
 
 function fetch_text() {
     local url="$1"
-    if [ "${fetcher}" == "lynx" ]; then
+    echo "${fetcher}" "${DOWNLINK_COMMAND}"
+    if [ "${fetcher}" == "${DOWNLINK_COMMAND}" ]; then
+        "${DOWNLINK_COMMAND}" "${url}"
+    elif [ "${fetcher}" == "lynx" ]; then
         # todo: support referer in lynx via -cfg file
         lynx --dump --nolist -useragent="${SCUTTLE_USER_AGENT}" "${url}"
     elif [ "${fetcher}" == "links" ]; then


### PR DESCRIPTION
This PR introduces a new Python script (`downlink.py`) to fetch webpages and convert them to Markdown.  It also adds a `fetcher.sh` script to abstract the fetching logic, supporting `downlink.py`, `lynx`, and `links`.

**Key changes:**

*   Added `examples/help-history.txt` to document recent work and provide context.
*   Created `scripts/downlink.py` for webpage-to-Markdown conversion.
*   Created `scripts/fetcher.sh` to handle webpage fetching with multiple tools.
*   Added `scripts/requirements.txt` to manage Python dependencies for `downlink.py`.
*   Refactored `scripts/scuttle.sh` and `scripts/summarize.sh` to utilize `fetcher.sh` for fetching content.
*   Updated `scripts/install-scripts.sh` to support Python virtual environment setup and dependency installation for `downlink.py`.

**Modified Files:**
    *   `llm_el/llm.el`: Fix scope bug in`llm-diff-region-with-string`.
    *   `scripts/install-scripts.sh`:  Added functionality to install Python dependencies (using `venv` and `pip`) specifically for the new `downlink.py` script.
    *   `scripts/scuttle.sh`:  Significant refactoring. The `lynx` and `links` fetcher logic has been moved to the new `scripts/fetcher.sh` script. The code now calls the `fetcher.sh` script to fetch content, simplifying the `scuttle.sh` file. The `fetch_text` function has been removed.
    *   `scripts/summarize.sh`:  Similar refactoring to `scuttle.sh`.  The fetcher logic has been moved to `scripts/fetcher.sh`, and the `fetch_text` function has been removed. It now calls `fetcher.sh` to retrieve the webpage content.

