### PR TITLE
Playwright: Refactor downlink script to use Playwright for rendering, update fetcher and install scripts, and update requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $ help.sh what can you do
 ## Brief Usage examples
 Below are brief examples to show you what these tools do.
 
-Install links to the scripts you want to use in your home bin directory. In the example below, symlink names have been shortened.
+Instal llinks to the scripts you want to use in your home bin directory. In the example below, symlink names have been shortened.
 
 ```shell
 $ help.sh -- "Split bash argument array into left and right with double hyphen as the separator using special bash builtin functions or operators"
@@ -421,7 +421,22 @@ Image pipelines are handled solely by @jartine https://justine.lol/oneliners/ an
 1. Context length and the number of gradient layers based on the priority mode (speed, length, or manual).
 1. Finally, perform inference using the specified model and parameters.
 
-# Mac Specifics
+# Installation
+Case 1: If you want to use links or lynx to fetch web pages, install them first.
+
+```
+$ sudo apt install linx lynx
+$ ./scripts/install-scripts.sh ~/bin
+```
+
+Case 2: Install the scripts for playwright headless browser usage:
+
+If you want to use playwright to fetch web pages, give the `--downlink` final argument to `install-scripts.sh`
+```bash
+$ ./scripts/install-scripts.sh ~/bin --downlink
+```
+
+## Mac Specifics
 You will need to do this on MacOS:
 ```
 $ cd ~/wip/llamafiles

--- a/scripts/downlink.py
+++ b/scripts/downlink.py
@@ -14,8 +14,8 @@ def fetch_rendered_html(url: str, user_agent: str) -> str:
     """Fetches the rendered HTML content of a URL using Playwright."""
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
-        page = browser.new_page()
-        page.set_user_agent(user_agent)  # Apply user agent here
+        context = browser.new_context(user_agent=user_agent)
+        page = context.new_page()
         try:
             page.goto(url, wait_until='networkidle')
         except Exception as e:

--- a/scripts/downlink.py
+++ b/scripts/downlink.py
@@ -1,31 +1,38 @@
 #!/usr/bin/env python3
 
-# pip install requests-html markdownify
-# See https://medium.com/@tubelwj/requests-html-an-html-parsing-library-in-python-8d182d13ecd2
-# Qwen2.5-Coder-32B-Instruct-Q5_K_S.gguf
+# pip install playwright markdownify
+# python -m playwright install
 
 import os
 import argparse
-from requests_html import HTMLSession
+from playwright.sync_api import sync_playwright
 from markdownify import markdownify as md
 
 USER_AGENT = """Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36"""
 
+def fetch_rendered_html(url: str, user_agent: str) -> str:
+    """Fetches the rendered HTML content of a URL using Playwright."""
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        page = browser.new_page()
+        page.set_user_agent(user_agent)  # Apply user agent here
+        try:
+            page.goto(url, wait_until='networkidle')
+        except Exception as e:
+            print(f"Error navigating to {url}: {e}")
+            return None
+        content = page.content()
+        browser.close()
+    return content
+
 def fetch_and_convert_to_markdown(url, user_agent):
-    session = HTMLSession(browser_args=[f"""--user-agent='{user_agent}'"""])
-    headers = { 'User-Agent': user_agent }
-    response = session.get(url, headers=headers)
-    
-    if response.status_code != 200:
-        print(f"Failed to fetch the URL. Status code: {response.status_code}")
+    """Fetches HTML, renders it with Playwright, and converts to Markdown."""
+    html = fetch_rendered_html(url, user_agent)
+    if html:
+        markdown_text = md(html)
+        return markdown_text
+    else:
         return None
-    
-    # Render JavaScript if necessary
-    response.html.render(timeout=16000)
-    
-    # Convert HTML to Markdown
-    markdown_text = md(response.html.html)
-    return markdown_text
 
 def main():
     parser = argparse.ArgumentParser(description="Convert a webpage to Markdown.")

--- a/scripts/fetcher.sh
+++ b/scripts/fetcher.sh
@@ -3,6 +3,7 @@
 # fetcher.sh - Fetches content from a URL using available tools
 
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
+VENV_ACTIVATE="${SCRIPT_DIR}/.venv/bin/activate"
 . "${SCRIPT_DIR}/../via/functions.sh"
 
 DEFAULT_USER_AGENT='Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36'
@@ -12,7 +13,7 @@ REFERER="https://scuttle.klotz.me" # abuse@hallux.ai
 
 usage() {
     echo "Usage: $(basename "$0") <URL>"
-    echo 'Obeys $USER_AGENT'
+    echo "Obeys \$USER_AGENT"
     exit 1
 }
 
@@ -24,13 +25,9 @@ fi
 
 DOWNLINK_COMMAND="${SCRIPT_DIR}/downlink.py"
 
-if [ -f "${SCRIPT_DIR}/.venv/bin/activate" ]; then
-    . "${SCRIPT_DIR}/.venv/bin/activate"
-fi
-
 if [ -n "${FETCHER}" ]; then
     true
-elif [ -x "${DOWNLINK_COMMAND}" ]; then
+elif [ -x "${DOWNLINK_COMMAND}" ] && [ -f "${VENV_ACTIVATE}" ]; then
     FETCHER="downlink"
 elif command -v lynx &> /dev/null; then
     FETCHER="lynx"
@@ -59,6 +56,7 @@ fi
 log_info "${FETCHER} fetching <${URL}>"
 case "${FETCHER}" in
     downlink)
+        . "${VENV_ACTIVATE}"
         if [ -z "${USER_AGENT}" ]; then
             "${DOWNLINK_COMMAND}" "${URL}"
         else

--- a/scripts/help-commit.sh
+++ b/scripts/help-commit.sh
@@ -72,7 +72,7 @@ printf -v MESSAGE_LINE '%s%s' "${OUTPUT_TYPE}" "${LINE_TYPE:+ with a $LINE_TYPE 
 default_system_message="$(printf "%b" "You are an expert in Linux, Bash, Python, general programming, and related topics.\n")"
 export SYSTEM_MESSAGE="${SYSTEM_MESSAGE:-${default_system_message}}"
 
-PROMPT="Describe the changes listed in the unified \`git diff\` below and output a ready-to-execute ${MESSAGE_LINE} command for the changes. In your output, pay attention to bash quoting syntax.\n"
+PROMPT="Describe the changes listed in the unified \`git diff\` below and output a ready-to-execute ${MESSAGE_LINE} for the changes. In your output, pay attention to bash quoting syntax.\n"
 
 if [ -z "${QUIET}" ]; then
     printf "%b\n" "${PROMPT}"

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -39,7 +39,12 @@ do
     lnf "${SCRIPT_DIR}/${file}" "${DEST_DIR}/${file}"
 done
 
+# Optional: install python .venv for downlink.py
+# todo: put this in DEST_DIR?
+
 cd "${SCRIPT_DIR}"
 python3 -m venv .venv
 . .venv/bin/activate
 pip3 install -r requirements.txt
+
+echo "* Installed in ${DEST_DIR} and ${SCRIPT_DIR}/.venv"

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -1,15 +1,50 @@
 #!/bin/bash
 
+# This script symlinks useful shell scripts to a destination directory.
+# It also optionally sets up a python virtual environment for 'downlink.py'.
+
 SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE}")")"
 
 FILES="ask.sh bashblock.sh codeblock.sh help-commit.sh machelp.sh manhelp.sh nvfree.sh onsubnet.sh peas.sh repofiles.sh scuttle.sh summarize-directory-files.sh summarize.sh systype.sh unfence.sh via.sh"
 SH_FILES="help.sh write.sh"
 
-DEST_DIR="${1}"
-if [ -z "${DEST_DIR}" ];
-then
-    echo "usage: $0: dest-dir"
-    exit 1
+DEST_DIR=""
+DOWNLINK_MODE=false
+
+usage() {
+  echo "Usage: $0 <dest-dir> [--downlink]"
+  echo ""
+  echo "  <dest-dir>      The destination directory to symlink scripts to."
+  echo "  --downlink      Enable downlink mode: installs python virtual environment and dependencies."
+  echo ""
+  echo "Example: $0 ~/bin --downlink"
+  exit 1
+}
+
+# Parse CLI options
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      ;;
+    --downlink)
+      DOWNLINK_MODE=true
+      shift
+      ;;
+    *)
+      if [ -z "$DEST_DIR" ]; then
+        DEST_DIR="$1"
+      else
+        echo "Error: Too many arguments."
+        usage
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "${DEST_DIR}" ]; then
+    usage
 fi
 
 function lnf {
@@ -24,8 +59,8 @@ function lnf {
 	echo "* ln -s ${src} ${dst}"
 	ln -s "${src}" "${dst}"
     else
-	true
 	#echo "${dst}" exists
+        true # Suppress output if file exists.
     fi
 }
 
@@ -39,12 +74,13 @@ do
     lnf "${SCRIPT_DIR}/${file}" "${DEST_DIR}/${file}"
 done
 
-# Optional: install python .venv for downlink.py
-# todo: put this in DEST_DIR?
-
-cd "${SCRIPT_DIR}"
-python3 -m venv .venv
-. .venv/bin/activate
-pip3 install -r requirements.txt
-
-echo "* Installed in ${DEST_DIR} and ${SCRIPT_DIR}/.venv"
+# Install python .venv for downlink.py
+if $DOWNLINK_MODE; then
+    echo "* Installing downlink dependencies in ${DEST_DIR}/.venv"
+    cd "${DEST_DIR}" || exit 1 # Important: cd into DEST_DIR for venv creation
+    python3 -m venv .venv
+    . .venv/bin/activate
+    pip3 install -r "${SCRIPT_DIR}/requirements.txt" #Use SCRIPT_DIR for requirements
+    playwright install
+    echo "* Downlink dependencies installed in ${DEST_DIR}/.venv"
+fi

--- a/scripts/install-scripts.sh
+++ b/scripts/install-scripts.sh
@@ -76,11 +76,12 @@ done
 
 # Install python .venv for downlink.py
 if $DOWNLINK_MODE; then
-    echo "* Installing downlink dependencies in ${DEST_DIR}/.venv"
-    cd "${DEST_DIR}" || exit 1 # Important: cd into DEST_DIR for venv creation
+    # install in script dir, not dest_dir, for now
+    echo "* Installing downlink dependencies in ${SCRIPT_DIR}/.venv"
+    cd "${SCRIPT_DIR}" || exit 1
     python3 -m venv .venv
     . .venv/bin/activate
     pip3 install -r "${SCRIPT_DIR}/requirements.txt" #Use SCRIPT_DIR for requirements
     playwright install
-    echo "* Downlink dependencies installed in ${DEST_DIR}/.venv"
+    echo "* Downlink dependencies installed in ${SCRIPT_DIR}/.venv"
 fi

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,2 @@
-requests_html
+playright
 markdownify
-lxml[html_clean]

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,2 @@
-playright
+playwright
 markdownify

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
 requests_html
 markdownify
-lxml_html_clean
+lxml[html_clean]


### PR DESCRIPTION
requests_html and pypeteer seem aged.

*   **`downlink.py`**: The script has been updated to use `playwright` instead of `requests-html` for fetching and rendering web pages.  `requests-html` has been removed as a dependency. The code now uses `playwright`'s `sync_api` to launch a Chromium browser in headless mode, navigate to the URL, and retrieve the rendered HTML content. Error handling has been improved with a `try...except` block when navigating to the URL.                                                                                                                                             
*   **`fetcher.sh`**: The script now checks for the existence of a `.venv/bin/activate` file *before* attempting to activate the virtual environment and use `downlink.py`. A variable `VENV_ACTIVATE` is introduced to store the path to the activation script.                                                                                                                           
*   **`install-scripts.sh`**: This script has been significantly enhanced.  It now supports an optional `--downlink` flag. If specified, it sets up a Python virtual environment (`.venv`), installs the necessary dependencies (including `playwright`), and runs `playwright install`. The script now parses command-line arguments to determine the destination directory and whether to enable downlink mode.  It also includes better error handling and usage instructions.                                                                                                       
*   **`requirements.txt`**: The dependency `requests-html` was removed and `playwright` was added.                                                                                            
